### PR TITLE
Unit_build_shortcuts_fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/options/Shortcuts.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/options/Shortcuts.txt
@@ -3633,7 +3633,7 @@ Root {
 	}
 	ActionMenu_650 {
 		Action = 'seas_helicopter_flying_Build_SEAS'
-		Shortcut = 'G'
+		Shortcut = 'Y'
 	}
 	ActionMenu_651 {
 		Action = 'seas_hovercraft_Build_SEAS'
@@ -4361,7 +4361,7 @@ Root {
 	}
 	ActionMenu_832 {
 		Action = 'headquarters_reactor_core_Upgrades_SEAS'
-		Shortcut = 'С'
+		Shortcut = 'C'
 	}
 	ActionMenu_833 {
 		Action = 'jail_part_01_reactor_core_Upgrades_SEAS'


### PR DESCRIPTION
Fix of the non–working 'seas_headquarters_reactor_core' Fixed the dublicate shortcut for the unit 'seas_helicopter_flying'