### PR TITLE
Heores lvl2 aura radius increase

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/character.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/character.usl
@@ -1115,7 +1115,7 @@ class CCharacter inherit CFightingObj
 			endif;
 			var real fRadius;
 			if(GetLevel()>=1)then
-				fRadius=20.0;
+				fRadius=30.0;
 			endif;
 			if(fRadius>0.0)then
 				var vec3 vD; vD.SetXYZ(fRadius, fRadius, 0.0);


### PR DESCRIPTION
Increase heroe's lvl 2 aura bonus for:
* Babbage radius increased from 20 to 30
* Bela radius increased from 20 to 30
* Cole radius increased from 20 to 30
* Larry radius increased from 30 to 35
* Livingstone radius increased from 20 to 30
* Lovelace radius increased from 20 to 30
* Mayor radius increased from 20 to 30
* Schliemann zombie radius increased from 20 to 30
* Stiina (infantry) radius increased from 20 to 30
* Stina (animal) radius increased from 25 to 30
* Miyagi eadius increased from 25 to 30
* Tarna radius increased from 20 to 30
* Tesla radius increased from 20 to 30
* Babbage mobile suit radius increased from 20 to 30