### PR TITLE
Schliemann_zombie lvl 2 aura mechanic fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -20,6 +20,7 @@ General:
 - Fixed non working wild animals selection sounds
 - Fixed similiar hotkey for Watchtower and Large dino farm
 - Fixed missing pirate boss ship dest textures
+- Fixed Zombie Schliemann aura in Valhalla's campaign mission
 - Reworked shortcuts for all units, added new ones
 - Restored intro playback for win 7 and higher (sometimes doesnt work)
 - Deleted unused weapon /Objects/Hu/Weapons/hu_falling_towers

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/Hero.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/Hero.usl
@@ -96,6 +96,10 @@ class CHero inherit CCharacter
 			SetIgnoreSlope(true);
 			DeleteTimer(LIVINGSTONE_TIMER);
 			CreateTimer(LIVINGSTONE_TIMER,CGameTimeSpan.OneSecond()*LIVINGSTONE_TICK_TIME, true);
+		elseif(GetClassName()=="schliemann_zombie")then
+			SetIgnoreSlope(true);
+			DeleteTimer(LIVINGSTONE_TIMER);
+			CreateTimer(LIVINGSTONE_TIMER,CGameTimeSpan.OneSecond()*LIVINGSTONE_TICK_TIME, true);
 		endif;
 		SetCanWalk(true);
 		var ^CAttribs pxAttr=GetAttribs();
@@ -255,6 +259,8 @@ class CHero inherit CCharacter
 			endif;
 		elseif(m_sRangedEffectPath.Find("schliemann_s0")>=0)then
 			pxO^.SetEffectFlag(CFightingObj.EFFECT_KLEEMANN_AURA, true);
+		elseif(m_sRangedEffectPath.Find("schliemann_zombie")>=0 && pxO^.GetType()!="BLDG")then
+			pxO^.AddRangedBuff("drain_life");
 		else
 			var ^CTechTreeDef pxTTDef=pxO^.GetTechTreeDef();
 			if(pxTTDef!=null)then
@@ -288,6 +294,8 @@ class CHero inherit CCharacter
 			pxO^.RemoveRangedBuff("drain_life");
 		elseif(m_sRangedEffectPath.Find("schliemann_s0")>=0)then
 			pxO^.SetEffectFlag(CFightingObj.EFFECT_KLEEMANN_AURA, false);
+		elseif(m_sRangedEffectPath.Find("schliemann_zombie")>=0)then
+			pxO^.RemoveRangedBuff("drain_life");
 		else
 			var ^CTechTreeDef pxTTDef=pxO^.GetTechTreeDef();
 			if(pxTTDef!=null)then
@@ -1451,6 +1459,8 @@ class CHero inherit CCharacter
 			RemoveRangedBuff("owner_stina");
 		elseif(sClassName=="schliemann_s0")then
 			RemoveRangedBuff("owner_schliemann");
+		elseif(sClassName=="schliemann_zombie")then
+			RemoveRangedBuff("owner_livingstone");
 		elseif(sClassName=="livingstone_s0")then
 			RemoveRangedBuff("owner_livingstone");
 		elseif(sClassName=="Tarna_s0")then


### PR DESCRIPTION
Long time ago i added the Zombie Schliemann from campaign an leighton vampiric aura, i added TT stats and later added region, but aura didnt worked, cuase i havent added mechanic because was unexperienced. Now aura works. Aura was added for unit that exists only on mission 8 of singleplayer and multicampaign for purpose to make boss fight atleast alittle harder and more insteresting.