### PR TITLE
prevented zero divisions and fixed visual issues

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -12234,40 +12234,11 @@ class CFightingObj inherit CGameObj
 		else //Kr1s1m: In case that we want to apply the disarm effect:
 			//Kr1s1m: First we stop the attack animations
 			ClearFightAnims();
-			//Kr1s1m: Second, we set all weapon related fields to their null value
-			begin ClearWeapons;
-				SetProjectile("");
-				SetProjectileGfx("");
-				SetDmg(0.0f);
-				SetMinDmg(0.0f);
-				SetEndDmg(0.0f);
-				SetProtection(0.0f);
-				SetRangedProtection(0.0f);
-				SetHitRange(0.0f);
-				SetRealHitRange(0.0f);
-				SetAttackRange(0.0f);
-				SetWeaponDuration(0.0f);
-				SetPenetrationAngle(0.0f);
-				SetPenetrationFactor(0.0f);
-				SetMinAttackRange(0.0f);
-				SetRealMinAttackRange(0.0f);
-				SetArmorPiercing(0.0f);
-				SetPoisonDmg(0.0f);
-				SetFireDmg(0.0f);
-				SetPenetration(false);
-				SetCanFightAir(false);
-				SetPoisonMaxTickCount(0);
-				SetBurnTime(0);
-				SetWeaponSizeClass(0);
-				m_pxWeaponMgr^.ClearAllWeapons();
-				ClearWeaponCache();
-				ClearDamageCache();
-			end ClearWeapons;
-			//Kr1s1m: Third, we erase the cleared weapon manager from the heap memory, and re-allocate it
-			begin RestoreWeaponMgr;
-				delete m_pxWeaponMgr;
-				m_pxWeaponMgr = new CWeaponMgr(this);
-			end RestoreWeaponMgr;
+			//Kr1s1m: Second, we clear all weapons and the weapon cache
+			m_pxWeaponMgr^.ClearAllWeapons();
+			ClearWeaponCache();
+			//Kr1s1m: Third, we update the visuals and the text
+			UpdateWeapons(GetRightHandWeapon());
 		endif;
 		//Kr1s1m: Last, we raise up the necessary flags
 		m_bWeaponHasChanged = true;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/Hero.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/Hero.usl
@@ -609,6 +609,7 @@ class CHero inherit CCharacter
 		if(HasTimer(LIVINGSTONE_VANISH_TIMER))then
 			return;
 		endif;
+		if(Disarmed())then return; endif; //Kr1s1m: GetDmg() = 0, zero division on next line if disarmed
 		var real fDamageFactor=LIVINGSTONE_TICK_DAMAGE / GetDmg();
 		var int i,iC=m_xRegionObjects.NumEntries();
 		for(i=0)cond(i<iC)iter(i++)do

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Miracle.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Miracle.usl
@@ -7622,6 +7622,7 @@ class CSpecialMinigun inherit CSpecialActionTask
 			for(i=0)cond(i<iC)iter(i++)do
 				var ^CFightingObj pxFight=cast<CFightingObj>(xList[i].GetObj());
 				if(pxFight!=null)then
+					if(pxCharacter^.Disarmed())then continue; endif; //Kr1s1m: GetDmg() = 0, zero division on next line if disarmed
 					var real fDamageFactor=(Math.Clamp((pxFight^.GetHitpoints()*0.01)*DAMAGE_PERCENT,DAMAGE_MINIMAL,DAMAGE_MAXIMAL) / pxCharacter^.GetDmg())*0.125;
 					pxFight^.ClearDamageCache();
 					pxFight^.TakeDmg(pxCharacter, true, fDamageFactor);

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/crashrpg/CrashRPG.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/crashrpg/CrashRPG.usl
@@ -8705,6 +8705,7 @@ class CCRpgNovice4 inherit CCRpgBaseChtr
 	endproc;
 	
 	proc void DrainEnemyLife()
+		if(Disarmed())then return; endif; //Kr1s1m: GetDmg() = 0, zero division on next line if disarmed
 		var real fDamageFactor=SHAOLIN_LIFE_DRAIN_DMG / GetDmg();
 		var int i,iC=m_xRegionObjects.NumEntries();
 		for(i=0)cond(i<iC)iter(i++)do
@@ -11880,6 +11881,7 @@ class CShooterMinigun inherit CSpecialActionTask
 			for(i=0)cond(i<iC)iter(i++)do
 				var ^CFightingObj pxFight = cast<CFightingObj>(xList[i].GetObj());
 				if(pxFight!=null)then
+					if(pxCharacter^.Disarmed())then continue; endif; //Kr1s1m: GetDmg() = 0, zero division on next line if disarmed
 					var real fDamageFactor = (Math.Clamp((pxFight^.GetHitpoints()*0.01)*DAMAGE_PERCENT,DAMAGE_MINIMAL,DAMAGE_MAXIMAL) / pxCharacter^.GetDmg())*0.125;
 					pxFight^.ClearDamageCache();
 					pxFight^.TakeDmg(pxCharacter, true, fDamageFactor);

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/BabbageMinigun.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/BabbageMinigun.usl
@@ -171,6 +171,7 @@ class CBabbageMinigun inherit CSpecialActionTask
 			for(i=0)cond(i<iC)iter(i++)do
 				var ^CFightingObj pxFight = cast<CFightingObj>(xList[i].GetObj());
 				if(pxFight!=null)then
+					if(pxCharacter^.Disarmed())then continue; endif; //Kr1s1m: GetDmg() = 0, zero division on next line if disarmed
 					var real fDamageFactor = (Math.Clamp((pxFight^.GetHitpoints()*0.01)*DAMAGE_PERCENT,DAMAGE_MINIMAL,DAMAGE_MAXIMAL) / pxCharacter^.GetDmg())*0.125;
 					pxFight^.ClearDamageCache();
 					pxFight^.TakeDmg(pxCharacter, true, fDamageFactor, fHitDelay, 100.0);


### PR DESCRIPTION
- heroes with specials or auras which damage calculation is based on their current damage will not be able to deal damage while they are disarmed (weapon remove enabled) because then their current damage becomes 0
- visually CHAR units will lose their weapon graphics when disarmed (weapon remove enabled) and ALL units/buildings will have empty attack and defense related values in their information block bellow army controller
- TODO: 1) Add status effect circular icon for disarm. 2) Make additional riders (not transported) with weapons such as balistas, launchers, bows be unable to fight while the entire unit (of which they are part) has been disarmed (weapon remove enabled)