### PR TITLE
seas great cannon auto fire does not target wild

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -6693,6 +6693,7 @@ class CFightingObj inherit CGameObj
 			var ^CFightingObj pxObj=cast<CFightingObj>(p_rxList[i].GetObj());
 			if(pxObj==null)then continue; endif;
 			if(pxObj^.IsFlyingUnit()&&!m_bAirWeapon&&!m_bBUAirAttack)then continue; endif;
+			if(pxObj^.IsWildAnimal() && GetClassName()=="seas_great_cannon")then continue; endif;
 			if(m_bFlyingUnit&&!pxObj^.IsFlyingUnit()&&GetProjectile().IsEmpty()&&!m_bWildPtera)then continue; endif;
 			if(pxObj^.IsMarkedForDelete())then continue; endif;
 			if(pxObj^.InvalidEnemy())then continue; endif;


### PR DESCRIPTION
- wild animals in range are skipped
- enemy tribe units and buildings are still targeted
- TODO: current solution has the tendency to prevent hunting and sometimes requires manual target of wild animals