### PR TITLE
fixed hunting bug caused by unhittable obj

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -14027,7 +14027,7 @@ class CFightingObj inherit CGameObj
 					continue;
 				endif;
 				var ^CFightingObj pxCandidat=cast<CFightingObj>(xPrey[0].GetObj());
-				if(pxCandidat!=null && (pxCandidat^.IsBaby() || !pxCandidat^.IsHitable()))then
+				if(pxCandidat==null || (pxCandidat!=null && (pxCandidat^.IsBaby() || !pxCandidat^.IsHitable())))then
 					xPrey.DeleteEntry(0);
 					continue;
 				endif;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/Fight.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/Fight.usl
@@ -828,7 +828,7 @@ class CFight inherit CTask
 					continue;
 				endif;
 				var ^CAnimal pxCandidat=cast<CAnimal>(xPrey[0].GetObj());
-				if(pxCandidat==null||pxCandidat^.IsBaby())then
+				if(pxCandidat==null || (pxCandidat!=null && (pxCandidat^.IsBaby() || !pxCandidat^.IsHitable())))then
 					xPrey.DeleteEntry(0);
 					continue;
 				endif;


### PR DESCRIPTION
- edited both CFightingObj class and CFight task, editing a key condition
- solves issues for campaign maps with deco objects