### PR TITLE
hq timer windows now scale properly in 4k

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/IngameScreen.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/IngameScreen.usl
@@ -1403,6 +1403,7 @@ class CInGameScreen inherit CWindow
 						var string sTooltip=pxAttribs^.GetValue("tooltip");
 						if(bShow)then
 							var ^CTimerWindow pxNewTimerWindow=new CTimerWindow(xTimerObj);
+							pxNewTimerWindow^.SetSize(pxNewTimerWindow^.GetWidth() * CGameInst.ms_iUIScaleFactor, pxNewTimerWindow^.GetHeight() * CGameInst.ms_iUIScaleFactor);
 							if(!sTooltip.IsEmpty())then
 								pxNewTimerWindow^.SetToolTipText(CUIMgr.GetLocalizedNewstickerMsg(sTooltip));
 							endif;


### PR DESCRIPTION
- TODO 1: fix the progress bar inside the timer window to also somehow scale with the game instance scale factor, which will also center the timer text tied to it
- TODO 2: create and add 4k asset to UIfor4k submod for the rounded timer window with the house image