### PR TITLE
dustriders resource tool upgrade and others now work properly

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -139,6 +139,7 @@ Heroes:
 - Anthony Cole Shotgun special now correctly collateraly damages all neutral units in the bullet cloud projectile path
 - Governor Whirling Blade special now correctly deals area damage to all neutral units in range
 - Governor Whirling Blade special area effect range increased to double the previous value
+- Larry, Barry and Harry are affected by Dustriders Town Center Resource tool upgrades 1,2,3 and 4
 - Babbage lvl 2 aura radius increased from 20 to 30
 - Bela lvl 2 aura radius increased from 20 to 30
 - Cole lvl 2 aura radius increased from 20 to 30
@@ -161,6 +162,7 @@ Dustriders:
 - Epoch 5 research cost updated from 1500/1500/750/100 to 2200/1800/0/100
 - Epoch 6 research cost updated from 2000/2000/1000/150 to 3000/2200/0/150
 - Town Center hit points reduced from 2000/2250/2750/3500/4500/5500 to 2000/2200/2500/2900/3400/4000
+- Town Center Resource tool upgrades 1,2,3, and 4 now correctly increase harvest speed but no longer affect build up and repair
 - T-Rex titan Stunning Roar special now only affects characters and animals, except other tyrannosaurus based units
 - T-Rex titan Stunning Roar special now correctly affects all neutral units instead of only aggressive
 - T-Rex titan melee attack armor penetration value set to 30

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/BuildUpBuilding.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/BuildUpBuilding.usl
@@ -426,7 +426,7 @@ class CBuildUpBuilding inherit CTask
 				begin CheckAjeResourceToolUpgrade;
 					var bool bLarryBrother = pxWorker^.GetClassName()=="Larry_s0" || pxWorker^.GetClassName()=="Barry_s0" || pxWorker^.GetClassName()=="Harry_s0";
 					if(pxWorker^.GetClassName()=="aje_worker" || bLarryBrother)then
-						var bool bAjeResourceToolUpgradeInvented = CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "aje_resource_tool_upgrade_1", pxBuilding^.GetTribeName());
+						var bool bAjeResourceToolUpgradeInvented = CRequirementsMgr.Get().CheckInvention(pxWorker, pxWorker^.GetOwner(), "aje_resource_tool_upgrade_1", pxWorker^.GetTribeName());
 						if(bAjeResourceToolUpgradeInvented)then //Kr1s1m: If Larries or workers have the aje resource tool upgrade...
 							fWorkerTimeFactor = 1.0;//Kr1s1m: ... then treat the current time factor as 100% (base) for the calculations bellow.
 						endif;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/BuildUpBuilding.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/BuildUpBuilding.usl
@@ -349,8 +349,8 @@ class CBuildUpBuilding inherit CTask
 				var ^CGameObj pxObj = xList[i].GetObj();
 				if(pxObj!=null)then
 					var bool bGoAway=false;
-					var ^CCharacter pxChar=cast<CCharacter>(pxObj);
-					if(pxChar==null||pxChar^.IsIdle()) then bGoAway=true; endif;
+					var ^CCharacter pxWorker=cast<CCharacter>(pxObj);
+					if(pxWorker==null||pxWorker^.IsIdle()) then bGoAway=true; endif;
 					if(bGoAway) then
 						var vec3 vDir = pxObj^.GetPos()-pxBldg^.GetPos();
 						vDir.Normalize();
@@ -418,10 +418,22 @@ class CBuildUpBuilding inherit CTask
 		endfor;*/
 		var real fMinTimeFactor=99.9;
 		iterloop(m_axWorkers,i) do
-			var ^CCharacter pxChar = cast<CCharacter>(m_axWorkers[i].GetObj());
-			if(pxChar!=null)then
-				if(fMinTimeFactor>pxChar^.GetSelfTimeFactor())then
-					fMinTimeFactor=pxChar^.GetSelfTimeFactor();
+			var ^CCharacter pxWorker = cast<CCharacter>(m_axWorkers[i].GetObj());
+			if(pxWorker!=null)then
+				var real fWorkerTimeFactor = pxWorker^.GetSelfTimeFactor();
+				//Kr1s1m: Initiate a check for Dustriders Resource Tool Upgrade in order to skip affecting build up speed.
+				//Kr1s1m: This was needed so the upgrade could be restored to its base game state.
+				begin CheckAjeResourceToolUpgrade;
+					var bool bLarryBrother = pxWorker^.GetClassName()=="Larry_s0" || pxWorker^.GetClassName()=="Barry_s0" || pxWorker^.GetClassName()=="Harry_s0";
+					if(pxWorker^.GetClassName()=="aje_worker" || bLarryBrother)then
+						var bool bAjeResourceToolUpgradeInvented = CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "aje_resource_tool_upgrade_1", pxBuilding^.GetTribeName());
+						if(bAjeResourceToolUpgradeInvented)then //Kr1s1m: If Larries or workers have the aje resource tool upgrade...
+							fWorkerTimeFactor = 1.0;//Kr1s1m: ... then treat the current time factor as 100% (base) for the calculations bellow.
+						endif;
+					endif;
+				end CheckAjeResourceToolUpgrade;
+				if(fMinTimeFactor>fWorkerTimeFactor)then
+					fMinTimeFactor=fWorkerTimeFactor;
 				endif;
 			endif;
 		enditerloop;
@@ -469,12 +481,12 @@ class CBuildUpBuilding inherit CTask
 		end CheckSEASBonus;
 		iterloop(m_axWorkers,i) do
 			if(m_axWorkers[i].IsValid())then
-				var ^CCharacter pxChar = cast<CCharacter>(m_axWorkers[i].GetObj());
-				if(pxChar!=null)then
+				var ^CCharacter pxWorker = cast<CCharacter>(m_axWorkers[i].GetObj());
+				if(pxWorker!=null)then
 					if(bTeslaBonus)then
-						pxChar^.AddRangedBuff("faster_buildup");
+						pxWorker^.AddRangedBuff("faster_buildup");
 					else
-						pxChar^.RemoveRangedBuff("faster_buildup");
+						pxWorker^.RemoveRangedBuff("faster_buildup");
 					endif;
 					if(xTempDuration.GetSecondsF()!=0.0)then
 						if(AddProgress(100.0*(xDiff.GetSecondsF()/(xTempDuration.GetSecondsF()))))then

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/Repair.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/Repair.usl
@@ -167,6 +167,17 @@ class CRepair inherit CTargetTask
 			if(pxWorker!=null)then
 				m_fStep+=(fLevelFactor*pxWorker^.GetLevel().ToReal());
 			endif;
+			//Kr1s1m: Initiate a check for Dustriders Resource Tool Upgrade in order to skip affecting repair speed.
+			//Kr1s1m: This was needed so the upgrade could be restored to its base game state.
+			begin CheckAjeResourceToolUpgrade;
+				var bool bLarryBrother = pxWorker^.GetClassName()=="Larry_s0" || pxWorker^.GetClassName()=="Barry_s0" || pxWorker^.GetClassName()=="Harry_s0";
+				if(pxWorker^.GetClassName()=="aje_worker" || bLarryBrother)then
+					var bool bAjeResourceToolUpgradeInvented = CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "aje_resource_tool_upgrade_1", pxBuilding^.GetTribeName());
+					if(bAjeResourceToolUpgradeInvented)then //Kr1s1m: If Larry or worker has the aje resource tool upgrade...
+						fDuration /= m_fTimeFactor; //Kr1s1m: ...undo the effect of the previously multiplied time factor.
+					endif;
+				endif;
+			end CheckAjeResourceToolUpgrade;
 			begin CheckSEASBonus;
 				var bool bSeasBetterToolsInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "seas_better_tools", pxBuilding^.GetTribeName());
 				if(pxWorker^.GetClassName()=="seas_worker")then

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/Repair.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/Repair.usl
@@ -172,7 +172,7 @@ class CRepair inherit CTargetTask
 			begin CheckAjeResourceToolUpgrade;
 				var bool bLarryBrother = pxWorker^.GetClassName()=="Larry_s0" || pxWorker^.GetClassName()=="Barry_s0" || pxWorker^.GetClassName()=="Harry_s0";
 				if(pxWorker^.GetClassName()=="aje_worker" || bLarryBrother)then
-					var bool bAjeResourceToolUpgradeInvented = CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "aje_resource_tool_upgrade_1", pxBuilding^.GetTribeName());
+					var bool bAjeResourceToolUpgradeInvented = CRequirementsMgr.Get().CheckInvention(pxWorker, pxWorker^.GetOwner(), "aje_resource_tool_upgrade_1", pxWorker^.GetTribeName());
 					if(bAjeResourceToolUpgradeInvented)then //Kr1s1m: If Larry or worker has the aje resource tool upgrade...
 						fDuration /= m_fTimeFactor; //Kr1s1m: ...undo the effect of the previously multiplied time factor.
 					endif;


### PR DESCRIPTION
- time factor restored like in Base game (used to temporarily increase resources carried similar to all other tribes due to  resolved issue in next point)
- upgrade no longer incorrectly affects build up and repair time like in Base game
- invention obj icons which were gone added back in unit info of workers TODO: Add icon to Larry (and brothers) since he is also affected. Doesn't work due to AddInventObj path value. Same with SEAS town center repair and buildup upgrades in relation to Taslow.
- **_UPDATE_**:
- added additional Invent Obj to split several upgrades (Larry, Taslow, Special Suit) by Tribe and Special in order to truly create a path (node) in TT
- upgrades (Larry, Taslow, Special Suit) now have icons and can correctly be verified for invention from USL (TODO from last commit complete!)