### PR TITLE
SEAS: improved repair, better tools, poison rounds, Ada

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -141,6 +141,8 @@ Heroes:
 - Governor Whirling Blade special now correctly deals area damage to all neutral units in range
 - Governor Whirling Blade special area effect range increased to double the previous value
 - Larry, Barry and Harry are affected by Dustriders Town Center Resource tool upgrades 1,2,3 and 4
+- Ada Loven musket range per level changed from 35/35/35/35/35 to 35/37/38/40/42
+- Ada Loven from now on has a poison upgrade (Kleeman tier 4) for ranged attack, poison damage is 5/7/10/15/20 per 10/11/12/14/15 ticks
 - Babbage lvl 2 aura radius increased from 20 to 30
 - Bela lvl 2 aura radius increased from 20 to 30
 - Cole lvl 2 aura radius increased from 20 to 30
@@ -225,7 +227,15 @@ SEAS:
 - Campaign Babbage mobile suit from now on has range attack damage upgrade just like terminator, damage multiplied on 1.1
 - Campaign Babbage mobile suit from now on has an armorpiercing range attack upgrade, armorpiercing is 100
 - Campaign Babbage mobile suit from now on has a poison upgrade for range attack just like terminator, poison damage is 100/125/150/180/200 per 15 ticks
-- Regular Babbage mobile suit from now on has a poison upgrade for range attack just like terminator, poison damage is same as for terminator
+- Regular Babbage mobile suit from now on has a poison upgrade (Kleeman tier 4) for ranged attack, poison damage is 5/7/10/15/20 per 10/11/12/14/15 ticks
+- Regular Babbage mobile suit now properly shows Poison Rounds upgrade icon when Kleeman is tier 4
+- Regular Babbage mobile suit now properly shows Maelstorm Rounds upgrade icon
+- Regular Babbage mobile suit now properly shows Robot Plating upgrade icon
+- Regular Babbage mobile suit now properly shows Hi Sec Auto Tracking upgrade icon
+- Improved repair and Advanced tools upgrades swapped - from now on their names and descriptions match
+- Improved repair costs 0/500/300/0 and increases repair speed (double repair ticks like before)
+- Advanced tools costs 200/200/200/0 and increases build up speed (+25% build speed like before)
+- Improved repair and Advanced tools now properly both affect Taslow and display upgrade icons
 
 AI:
 - AI now detects and threats the specific heroe units as Hero Classes: Babbage mobile suit, and Schliemann zombie (custom map hero)

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/BuildUpBuilding.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/BuildUpBuilding.usl
@@ -472,7 +472,7 @@ class CBuildUpBuilding inherit CTask
 			if(m_xBuilding.IsValid())then
 				var ^CGameObj pxBldg = m_xBuilding.GetObj();
 				if(pxBldg!=null && cast<CWarpGate>(pxBldg)==null)then
-					var bool bSeasBetterToolsOneInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "improved_repair", pxBuilding^.GetTribeName());
+					var bool bSeasBetterToolsOneInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "seas_better_tools", pxBuilding^.GetTribeName());
 					if(bSeasBetterToolsOneInvented)then
 						xDiff/=SEAS_BETTER_TOOLS;
 					endif;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/Repair.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/task/Repair.usl
@@ -179,8 +179,8 @@ class CRepair inherit CTargetTask
 				endif;
 			end CheckAjeResourceToolUpgrade;
 			begin CheckSEASBonus;
-				var bool bSeasBetterToolsInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "seas_better_tools", pxBuilding^.GetTribeName());
-				if(pxWorker^.GetClassName()=="seas_worker")then
+				var bool bSeasBetterToolsInvented=CRequirementsMgr.Get().CheckInvention(pxBuilding, pxBuilding^.GetOwner(), "improved_repair", pxBuilding^.GetTribeName());
+				if(pxWorker^.GetClassName()=="seas_worker" || pxWorker^.GetClassName()=="tesla_s0")then
 					if(bSeasBetterToolsInvented)then
 						m_fStep*=SEAS_IMPROVED_REPAIR;
 					endif;


### PR DESCRIPTION
- swapped SEAS improved repair and better tools upgrades in order to better match usl script variable names, effect, cost, icons and tooltip description
- improved repair and better tools both work properly with workers and Taslow
- poison rounds (tier 4 Kleeman bonus  for SEAS) now has icon for affected heroes, Ada added to affected heroes, damage and ticks are now based on level for both Ada and Special Suit version of Babbit (SEAS player upgrade)
- Ada's musket range now scales with her level going from 35 to 42 (at tier 5)
- SEAS Reactor core upgrade hidden for the currently disabled seas_jail_part_02