### PR TITLE
Campaign objects FOW visibility

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/Building.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/Building.usl
@@ -1717,6 +1717,13 @@ class CBuilding inherit CFightingObj
 	
 endclass;
 
+class CBuildingFOWVIsible inherit CBuilding
+	export proc void OnInit(bool p_bLoad)
+		super.OnInit(p_bLoad);
+		SetVisInFOW(true);
+	endproc;
+endclass;
+
 class CNoFreeBorderBlockerBuilding inherit CBuilding
 	export proc void OnInit(bool p_bLoad)
 		super.OnInit(p_bLoad);

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/seas_wwi.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/seas_wwi.txt
@@ -166,7 +166,7 @@ Root {
 	}
 	seas_hq_gate {
 		classattribs {
-			classname = 'CGate'
+			classname = 'CGateFOWVIsible'
 			gfx = 'seas_hq_gate'
 		}
 		objectattribs {

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/sl_hc_level_13.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/sl_hc_level_13.txt
@@ -7,7 +7,7 @@ Root {
 	}
 	hcl13_city_wall {
 		classattribs {
-			classname = 'CBuilding'
+			classname = 'CBuildingFOWVIsible'
 			gfx = 'hcl13_city_wall'
 		}
 		objectattribs {
@@ -25,7 +25,7 @@ Root {
 	}
 	hcl13_gate {
 		classattribs {
-			classname = 'CGate'
+			classname = 'CGateFOWVIsible'
 			gfx = 'hcl13_gate'
 		}
 		objectattribs {


### PR DESCRIPTION
Making some of campaign objects always visible in FOW. 
Usage: singleplayer and multicampaign.