### PR TITLE
Singleplayer campaign gates animation fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -1,7 +1,34 @@
-MIRAGE 2.6.6 (January 01 2024)
+MIRAGE 2.6.7 (January 01 2024)
 ===============================================================
 
 Change Log:
+
+MIRAGE 2.6.7
+------------------
+
+Special:
+
+General:
+- Holy city gates on skirmish maps and in mission 13 are playing "Open" animation from now on
+- Pirate ship chain on skirmish maps and in mission 6 are playing "Open" & "Close" animation from now on
+- Fixed bug with Holy City gates destruction animation wasnt playing
+
+Maps:
+
+Campaign maps:
+
+Heroes:
+
+Dustriders:
+
+Dragon Clan:
+
+Norsemen:
+
+SEAS:
+
+AI:
+
 
 MIRAGE 2.6.6
 ------------------

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/Building.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/Building.usl
@@ -3812,9 +3812,25 @@ class CGate inherit CBuilding
 				iLastAnimFrame=40;
 			endif;
 			if(m_iState==GATE_STATE_OPEN)then
-				SetAnim("open",0,iLastAnimFrame);
+				if(sGFX.Find("hcl13_gate")!=-1)then
+					iLastAnimFrame=45;
+					SetAnim("anim",0,iLastAnimFrame);
+				elseif(sGFX.Find("ship_chain")!=-1)then
+					iLastAnimFrame=250;
+					SetAnim("open_anim",0,iLastAnimFrame);
+				else
+					SetAnim("open",0,iLastAnimFrame);
+				endif;
 			elseif(m_iState==GATE_STATE_CLOSED||m_iState==GATE_STATE_AUTO)then
-				SetAnim("close",0,iLastAnimFrame);
+				if(sGFX.Find("hcl13_gate")!=-1)then
+					iLastAnimFrame=45;
+					SetAnim("anim",iLastAnimFrame,0);
+				elseif(sGFX.Find("ship_chain")!=-1)then
+					iLastAnimFrame=250;
+					SetAnim("open_anim",iLastAnimFrame,0);
+				else
+					SetAnim("close",0,iLastAnimFrame);
+				endif;
 			endif;
 			return true;
 		endif;
@@ -3832,6 +3848,13 @@ class CGate inherit CBuilding
 	endproc;
 	
 	proc void Open()
+		// added by ParaworldFan
+		var string sGFX=m_xTechTree.GetValueS(GetObjPath()+"/gfx","");
+		KLog.LogSpam("Campaign_gate","sGFX:"+sGFX);
+		SetGFX(sGFX);
+		UpdateObjPath();
+		OnTechTreeChange();
+		//
 		if(m_iState==GATE_STATE_OPEN)then return; endif; //redundant
 		if(m_xHackers.NumEntries()>0)then
 			OpenViolently(true);
@@ -3839,7 +3862,14 @@ class CGate inherit CBuilding
 		if(HasTimer(AUTO_GATE_TIMER))then
 			DeleteTimer(AUTO_GATE_TIMER);
 		else
-			SetAnim("open",1);
+			if(sGFX.Find("hcl13_gate")!=-1)then
+				KLog.LogSpam("Campaign_gate","sGFX.Find(hcl13_gate)!=-1"+" true");
+				SetAnim("open",1);
+			elseif(sGFX.Find("ship_chain")!=-1)then
+				SetAnim("open_anim",1);
+			else
+				SetAnim("open",1);
+			endif;
 		endif;
 		m_iState=GATE_STATE_OPEN;
 		SetPFBlocking();
@@ -3847,6 +3877,13 @@ class CGate inherit CBuilding
 	endproc;
 	
 	proc void Close()
+		// added by ParaworldFan
+		var string sGFX=m_xTechTree.GetValueS(GetObjPath()+"/gfx","");
+		KLog.LogSpam("Campaign_gate","sGFX:"+sGFX);
+		SetGFX(sGFX);
+		UpdateObjPath();
+		OnTechTreeChange();
+		//
 		if(m_iState==GATE_STATE_CLOSED)then return; endif; //redundant
 		if(HasTimer(BROCKEN_TIMER))then return; endif;
 		var bool bSetAnim=true;
@@ -3855,17 +3892,38 @@ class CGate inherit CBuilding
 		elseif(m_iState==GATE_STATE_AUTO)then
 			bSetAnim=false;
 		endif;
-		if(bSetAnim)then SetAnim("close",1); endif;
+		if(bSetAnim)then
+			if(sGFX.Find("hcl13_gate")!=-1)then
+				SetAnim("anim",0,0);
+			elseif(sGFX.Find("ship_chain")!=-1)then
+				SetAnim("open_anim",1);
+			else
+				SetAnim("close",1);
+			endif;
+		endif;
 		m_iState=GATE_STATE_CLOSED;
 		SetPFBlocking();
 		UpdateStateAttrib();
 	endproc;
 	
 	proc void Auto()
+		// added by ParaworldFan
+		var string sGFX=m_xTechTree.GetValueS(GetObjPath()+"/gfx","");
+		KLog.LogSpam("Campaign_gate","sGFX:"+sGFX);
+		SetGFX(sGFX);
+		UpdateObjPath();
+		OnTechTreeChange();
+		//
 		if(m_iState==GATE_STATE_AUTO)then return; endif; //redundant
 		if(HasTimer(BROCKEN_TIMER))then return; endif;
 		if(m_iState!=GATE_STATE_CLOSED)then
-			SetAnim("close",1);
+			if(sGFX.Find("hcl13_gate")!=-1)then
+				SetAnim("anim",2);
+			elseif(sGFX.Find("ship_chain")!=-1)then
+				SetAnim("open_anim",2);
+			else
+				SetAnim("close",1);
+			endif;
 		endif;
 		m_iState=GATE_STATE_AUTO;
 		SetPFBlocking();
@@ -3873,12 +3931,25 @@ class CGate inherit CBuilding
 	endproc;
 	
 	proc void OnAutoGatePassUnit()
+		// added by ParaworldFan
+		var string sGFX=m_xTechTree.GetValueS(GetObjPath()+"/gfx","");
+		KLog.LogSpam("Campaign_gate","sGFX:"+sGFX);
+		SetGFX(sGFX);
+		UpdateObjPath();
+		OnTechTreeChange();
+		//
 		if(m_iState!=GATE_STATE_AUTO)then return; endif;
 		//KLog.LogWarn("CHP","Gate\n");
 		if(HasTimer(AUTO_GATE_TIMER))then
 			DeleteTimer(AUTO_GATE_TIMER);
 		else
-			SetAnim("open",1);
+			if(sGFX.Find("hcl13_gate")!=-1)then
+				SetAnim("anim",1);
+			elseif(sGFX.Find("ship_chain")!=-1)then
+				SetAnim("open_anim",1);
+			else
+				SetAnim("open",1);
+			endif;
 		endif;
 		CreateTimer(AUTO_GATE_TIMER,CGameTimeSpan.OneSecond()*8.0,false);
 	endproc;
@@ -4059,6 +4130,13 @@ class CGate inherit CBuilding
 	
 	proc void HandleEvent(ref CGameEvtPtr p_rxEvtPtr)
 		super.HandleEvent(p_rxEvtPtr);
+		// added by ParaworldFan
+		var string sGFX=m_xTechTree.GetValueS(GetObjPath()+"/gfx","");
+		KLog.LogSpam("Campaign_gate","sGFX:"+sGFX);
+		SetGFX(sGFX);
+		UpdateObjPath();
+		OnTechTreeChange();
+		//
 		if(p_rxEvtPtr.GetClass()==ms_xTimerClass)then
 			if(p_rxEvtPtr.GetInt(0)==BROCKEN_TIMER )then
 				DeleteTimer(BROCKEN_TIMER);
@@ -4071,7 +4149,13 @@ class CGate inherit CBuilding
 				DeleteTimer(STONES_RELOAD_TIMER);
 			elseif(p_rxEvtPtr.GetInt(0)==AUTO_GATE_TIMER)then
 				if(m_iState==GATE_STATE_AUTO)then
-					SetAnim("close",1);
+					if(sGFX.Find("hcl13_gate")!=-1)then
+						SetAnim("anim",2);
+					elseif(sGFX.Find("ship_chain")!=-1)then
+						SetAnim("open_anim",2);
+					else
+						SetAnim("close",1);
+					endif;
 				endif;
 			endif;
 		endif;


### PR DESCRIPTION
Campaign gates, whose models originally dont have required animation from now on playing aniamtions "Open" & "Close"
* "hcl13_gate" — Holy City Gates on mission 13
* "ship_chain" — pirate water ship chain on mission 6
* Fixed bug with incorrect model name in TechTree for "hcl13_gate"
* Fixed incorrect classnames for ninigi gates in Gate command functions in TechTree
* All normal and campaign gates from now have TechTree strings for the Open() Close() & Auto() commands TODO:
* "Close" animation still doesnt work for the "hcl13_gate"
* Repair Automatic mode for all campaign gates
* Repair blocker for "hcl13_gate", collision