### PR TITLE
BoosterPack avatar campaign death animation fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -13,6 +13,7 @@ General:
 - Holy city gates on skirmish maps and in mission 13 are playing "Open" animation from now on
 - Pirate ship chain on skirmish maps and in mission 6 are playing "Open" & "Close" animation from now on
 - Fixed bug with Holy City gates destruction animation wasnt playing
+- Campaing avatar on mission "Single B42: COld Day in Hell" has a corpse damage, and death animation from now on
 
 Maps:
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/BoosterPack1/bpone_character.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/BoosterPack1/bpone_character.txt
@@ -1,7 +1,7 @@
 Root {
 	hu_avatar {
 		classattribs {
-			classname = 'CHu'
+			classname = 'CHuAvatarStatue'
 			gfx = 'Avatar'
 		}
 		objectattribs {

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/Hu.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/Hu.usl
@@ -500,3 +500,33 @@ class CHuStoneStatue inherit CHu
 	endproc;
 
 endclass;
+
+class CHuAvatarStatue inherit CHu
+
+	export proc void CreateCorpse()
+		var string sGfx="Golem_dest";
+		if(!CSrvWrap.GetGfxMgrBase().FindGraphicSetEntry(sGfx))then return; endif;
+		if(CMirageSrvMgr.Get().UnitResources())then
+			var ^CStone_Corpse pxStone=cast<CStone_Corpse>(CSrvWrap.GetObjMgr()^.CreateObj("StoneCorpse",GetOwner(),GetPos(),GetRotation()));
+			if(pxStone!=null)then
+				pxStone^.SetName(GetName());
+				pxStone^.SetGFX(sGfx);
+				pxStone^.Initialize(this);
+				pxStone^.SetDieAnim("destroy",true);
+				pxStone^.AreaDamage(3.0);
+				pxStone^.SetAggressive(GetTechTreeAggressiv());
+				pxStone^.Init();
+			endif;
+		else
+			var ^CVehicleCorpse pxGameObj=cast<CVehicleCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("VehicleCorpse",GetOwner(),GetPos(),GetRotation()));
+			if(pxGameObj!=null)then
+				pxGameObj^.SetSource(this);
+				pxGameObj^.Init(sGfx, "destroy", GetName(), 10.0);
+				if(GetClassName()=="hu_avatar")then
+					pxGameObj^.AreaDamage(3.0);
+				endif;
+			endif;
+		endif;
+	endproc;
+	
+endclass;


### PR DESCRIPTION
From now on, "hu_avatar" has a corpse, coprse damage and "death" animation TODO: change Texture of the "white stone golem" to the "granite one" for death model