### PR TITLE
Campaign Vallhalla Golem statues corpse resources value fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -13,8 +13,9 @@ General:
 - Holy city gates on skirmish maps and in mission 13 are playing "Open" animation from now on
 - Pirate ship chain on skirmish maps and in mission 6 are playing "Open" & "Close" animation from now on
 - Fixed bug with Holy City gates destruction animation wasnt playing
-- Campaing avatar on mission "Single B42: COld Day in Hell" has a corpse damage, and death animation from now on
+- Campaing avatar on mission "Single B42: Cold Day in Hell" has a corpse damage, corpse resources and death animation from now on
 - Fixed missing stances icons
+- Fixed non working corpse resources values for campaign valhalla stone statues and campaign avatar
 
 Maps:
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
@@ -15016,10 +15016,15 @@ class CStone_Corpse inherit CStone
 		var ^CVehicle pxVehicle=cast<CVehicle>(p_pxObj);
 		if(pxVehicle!=null)then
 			var bool bUpdate=UpdateValues(pxVehicle);
-		else
+		elseif(p_pxObj^.GetClassName()=="special_mobile_suit")then
 			var ^CSpecialMobileSuit pxSuit=cast<CSpecialMobileSuit>(p_pxObj);
 			if(pxSuit!=null)then
 				var bool bUpdate=UpdateValues(pxSuit);
+			endif;
+		else
+			var ^CCharacter pxCharacter=cast<CCharacter>(p_pxObj);
+			if(pxCharacter!=null)then
+				var bool bUpdate=UpdateValuesSpecial(pxCharacter);
 			endif;
 		endif;
 		var ^CAttribs pxAttribs=GetAttribs();
@@ -15131,6 +15136,29 @@ class CStone_Corpse inherit CStone
 				var ^CPropDB.CNode pxType=pxRoot^.Get("STON");
 				if(pxType!=null)then
 					var ^CPropDB.CNode pxResource=pxType^.Get(p_pxVehicle^.GetClassName()+"_wreck");
+					if(pxResource!=null)then
+						m_fValue=pxResource^.GetValueI("value").ToReal();
+						pxAttribs^.SetValue("value",m_fValue.ToInt());
+						pxAttribs^.SetValue("hitpoints",m_fValue.ToInt());
+						pxAttribs^.SetValue("maxhitpoints",m_fValue.ToInt());
+					endif;
+				endif;
+			endif;
+		endif;
+		return true;
+	endproc;
+	
+	//ParaworldFan: "UpdateValues" for specific classnames, that are "CHTR" type, but with "STONE" corpse resource
+	export proc bool UpdateValuesSpecial(^CCharacter p_pxCharacter)
+		if(p_pxCharacter==null)then return true; endif;
+		var ^CAttribs pxAttribs=GetAttribs();
+		var ^CPropDB pxTable=CServerApp.GetPropDB_Resources();
+		if(pxTable!=null)then
+			var ^CPropDB.CNode pxRoot=^(pxTable^.GetRoot());
+			if(pxRoot!=null)then
+				var ^CPropDB.CNode pxType=pxRoot^.Get("STON");
+				if(pxType!=null)then
+					var ^CPropDB.CNode pxResource=pxType^.Get(p_pxCharacter^.GetClassName()+"_wreck");
 					if(pxResource!=null)then
 						m_fValue=pxResource^.GetValueI("value").ToReal();
 						pxAttribs^.SetValue("value",m_fValue.ToInt());

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/settings/Resources.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/settings/Resources.txt
@@ -422,6 +422,9 @@ Root {
 		hu_berserk_statue_04_wreck {
 			value = '500'
 		}
+		hu_avatar_wreck {
+			value = '500'
+		}
 		hu_mobile_suit_wreck {
 			value = '200'
 		}


### PR DESCRIPTION
Fixed issue, that unique campaign units:
"hu_berserk_statue_01"
"hu_berserk_statue_02"
"hu_berserk_statue_03"
"hu_berserk_statue_04"
"hu_avatar"
"hu_stone_statue"
were not getting their corpse resources values from settings file, they had base values before Also "hu_avatar" from now on have value strings in Resource.txt settings