### PR TITLE
Revert "mirage server FoW settings are now tied to level settings FoW checkbox"

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/Mirage_UI_scripts.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/Mirage_UI_scripts.usl
@@ -1,4 +1,4 @@
-//ParaworldFan multicamapign: file responsible for "MIRAGE Server" checkboxes
+
 class CMirageServer inherit CWindow
 	
 	export constructor()
@@ -316,7 +316,7 @@ class CMirageServer inherit CWindow
 		var CConfig xConf;
 		var ^CGame pxGame = ^(CGameWrap.GetGame());
 		var bool bOn=pxGame^.GetAttribInt(sName)==1||xConf.GetSetB("Server/GameplayOptions/"+sName,false);
-		var bool bDeny = pxGame^.GetAttribInt("GameType")!=0 || pxGame^.GetDiplomacyLocked() || CMultiPlayerClientMgr.Get().GetNumPlayers()<3;// || CheckCustomMap(sLevelName);
+		var bool bDeny = pxGame^.GetAttribInt("GameType")!=0 || pxGame^.GetDiplomacyLocked() || CMultiPlayerClientMgr.Get().GetNumPlayers()<3;
 		var bool bEnabled, bRandom;
 		var int iC, iD;
 		if(bDeny)then
@@ -393,51 +393,6 @@ class CMirageServer inherit CWindow
 		return(true);
 	endproc;
 	
-	export proc bool OnEnableAnimalsVisInFOWEx()
-		var string sName="AnimalsVisInFOW";
-		var CConfig xConf;
-		var ^CGame pxGame = ^(CGameWrap.GetGame());
-		var bool bOn=pxGame^.GetAttribInt(sName)==1;
-		var bool bAllow = pxGame^.GetFOWEnabled();
-		if(!bOn)then
-			return true;
-		elseif(!bAllow)then
-			xConf.SetB("Server/GameplayOptions/"+sName, false);
-			pxGame^.SetAttrib(sName,false);
-		endif;
-		return(true);
-	endproc;
-	
-	export proc bool OnEnableAttackInFOWEx()
-		var string sName="AttackInFOW";
-		var CConfig xConf;
-		var ^CGame pxGame = ^(CGameWrap.GetGame());
-		var bool bOn=pxGame^.GetAttribInt(sName)==1;
-		var bool bAllow = pxGame^.GetFOWEnabled();
-		if(!bOn)then
-			return true;
-		elseif(!bAllow)then
-			xConf.SetB("Server/GameplayOptions/"+sName, false);
-			pxGame^.SetAttrib(sName,false);
-		endif;
-		return(true);
-	endproc;
-	
-	export proc bool OnEnableShowResourcesInFOWEx()
-		var string sName="ShowResourcesInFOW";
-		var CConfig xConf;
-		var ^CGame pxGame = ^(CGameWrap.GetGame());
-		var bool bOn=pxGame^.GetAttribInt(sName)==1;
-		var bool bAllow = pxGame^.GetFOWEnabled();
-		if(!bOn)then
-			return true;
-		elseif(!bAllow)then
-			xConf.SetB("Server/GameplayOptions/"+sName, false);
-			pxGame^.SetAttrib(sName,false);
-		endif;
-		return(true);
-	endproc;
-	
 	export proc bool OnEnablePortalsEx()
 		var string sName="Portals";
 		var CConfig xConf;
@@ -473,7 +428,7 @@ class CMirageServer inherit CWindow
 		var CConfig xConf;
 		var ^CGame pxGame = ^(CGameWrap.GetGame());
 		var bool bOn=pxGame^.GetAttribInt(sName)==1;
-		var bool bDeny = pxGame^.GetAttribInt("GameType")!=0 || pxGame^.GetDiplomacyLocked() || CMultiPlayerClientMgr.Get().GetNumPlayers()<3;// || CheckCustomMap(sLevelName);
+		var bool bDeny = pxGame^.GetAttribInt("GameType")!=0 || pxGame^.GetDiplomacyLocked() || CMultiPlayerClientMgr.Get().GetNumPlayers()<3;
 		if(!bOn)then
 			return true;
 		elseif(bDeny)then
@@ -544,7 +499,7 @@ class CMirageServer inherit CWindow
 			var ^CSpinCtrlNumber pxSpinCtrl;
 			var ^CButton pxButton;
 			var string sName;
-			var bool bEnabled, bAllow;
+			var bool bEnabled;
 			var int iSetting, iDef, iStep, k, iK;
 			SetPos((CClientWrap.GetDesktop()^.GetSize().GetX()/2)-GetSize().GetX()/2,(CClientWrap.GetDesktop()^.GetSize().GetY()/2)-GetSize().GetY()/2);
 			
@@ -573,17 +528,10 @@ class CMirageServer inherit CWindow
 			sName="AnimalsVisInFOW";
 			pxCheckBox=cast<CCheckBox>(GetControl(sName));
 			bEnabled=xConf.GetSetB("Server/GameplayOptions/"+sName,false);
-			bAllow = pxGame^.GetFOWEnabled();
-			if(!bAllow)then
-				pxCheckBox^.SetChecked(0);
-				pxCheckBox^.SetDisabled(true);
+			if(bEnabled)then
+				pxCheckBox^.SetChecked(1);
 			else
-				if(bEnabled)then
-					pxCheckBox^.SetChecked(1);
-				else
-					pxCheckBox^.SetChecked(0);
-				endif;
-				pxCheckBox^.SetDisabled(false);
+				pxCheckBox^.SetChecked(0);
 			endif;
 			pxCheckBox^.m_xOnStateChange=OnEnableAnimalsVisInFOW;
 			pxGame^.SetAttrib(sName,bEnabled);
@@ -591,17 +539,10 @@ class CMirageServer inherit CWindow
 			sName="ShowResourcesInFOW";
 			pxCheckBox=cast<CCheckBox>(GetControl(sName));
 			bEnabled=xConf.GetSetB("Server/GameplayOptions/"+sName,false);
-			bAllow = pxGame^.GetFOWEnabled();
-			if(!bAllow)then
-				pxCheckBox^.SetChecked(0);
-				pxCheckBox^.SetDisabled(true);
+			if(bEnabled)then
+				pxCheckBox^.SetChecked(1);
 			else
-				if(bEnabled)then
-					pxCheckBox^.SetChecked(1);
-				else
-					pxCheckBox^.SetChecked(0);
-				endif;
-				pxCheckBox^.SetDisabled(false);
+				pxCheckBox^.SetChecked(0);
 			endif;
 			pxCheckBox^.m_xOnStateChange=OnEnableShowResourcesInFOW;
 			pxGame^.SetAttrib(sName,bEnabled);
@@ -655,16 +596,8 @@ class CMirageServer inherit CWindow
 			var string sName="AnimalsVisInFOW";
 			var ^CCheckBox pxTmp=cast<CCheckBox>(GetControl(sName));
 			var CConfig xConf;
-			var ^CGame pxGame = ^(CGameWrap.GetGame());
-			var bool bAllow = pxGame^.GetFOWEnabled();
-			if(!bAllow)then
-				pxTmp^.SetChecked(0);
-				pxTmp^.SetDisabled(true);
-			else
-				pxTmp^.SetDisabled(false);
-			endif;
 			xConf.SetB("Server/GameplayOptions/"+sName,pxTmp^.GetCheckMark());
-			pxGame^.SetAttrib(sName,pxTmp^.GetCheckMark());
+			CGameWrap.GetGame().SetAttrib(sName,pxTmp^.GetCheckMark());
 			return(true);
 		endproc;
 		
@@ -672,16 +605,8 @@ class CMirageServer inherit CWindow
 			var string sName="ShowResourcesInFOW";
 			var ^CCheckBox pxTmp=cast<CCheckBox>(GetControl(sName));
 			var CConfig xConf;
-			var ^CGame pxGame = ^(CGameWrap.GetGame());
-			var bool bAllow = pxGame^.GetFOWEnabled();
-			if(!bAllow)then
-				pxTmp^.SetChecked(0);
-				pxTmp^.SetDisabled(true);
-			else
-				pxTmp^.SetDisabled(false);
-			endif;
 			xConf.SetB("Server/GameplayOptions/"+sName,pxTmp^.GetCheckMark());
-			pxGame^.SetAttrib(sName,pxTmp^.GetCheckMark());
+			CGameWrap.GetGame().SetAttrib(sName,pxTmp^.GetCheckMark());
 			return(true);
 		endproc;
 		
@@ -1383,17 +1308,10 @@ class CMirageServer inherit CWindow
 			sName="AttackInFOW";
 			pxCheckBox=cast<CCheckBox>(GetControl(sName));
 			bEnabled=xConf.GetSetB("Server/GameplayOptions/"+sName,false);
-			bAllow = pxGame^.GetFOWEnabled();
-			if(!bAllow)then
-				pxCheckBox^.SetChecked(0);
-				pxCheckBox^.SetDisabled(true);
+			if(bEnabled)then
+				pxCheckBox^.SetChecked(1);
 			else
-				if(bEnabled)then
-					pxCheckBox^.SetChecked(1);
-				else
-					pxCheckBox^.SetChecked(0);
-				endif;
-				pxCheckBox^.SetDisabled(false);
+				pxCheckBox^.SetChecked(0);
 			endif;
 			pxCheckBox^.m_xOnStateChange=OnEnableAttackInFOW;
 			pxGame^.SetAttrib(sName,bEnabled);
@@ -1588,16 +1506,8 @@ class CMirageServer inherit CWindow
 			var string sName="AttackInFOW";
 			var ^CCheckBox pxTmp=cast<CCheckBox>(GetControl(sName));
 			var CConfig xConf;
-			var ^CGame pxGame = ^(CGameWrap.GetGame());
-			var bool bAllow = pxGame^.GetFOWEnabled();
-			if(!bAllow)then
-				pxTmp^.SetChecked(0);
-				pxTmp^.SetDisabled(true);
-			else
-				pxTmp^.SetDisabled(false);
-			endif;
-			xConf.SetB("Server/GameplayOptions/"+sName, pxTmp^.GetCheckMark());
-			pxGame^.SetAttrib(sName,pxTmp^.GetCheckMark());
+			xConf.SetB("Server/GameplayOptions/"+sName,pxTmp^.GetCheckMark());
+			CGameWrap.GetGame().SetAttrib(sName,pxTmp^.GetCheckMark());
 			return(true);
 		endproc;
 		

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/MultiplayerClientMgr.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/MultiplayerClientMgr.usl
@@ -1,4 +1,3 @@
-//ParaworldFan: in this file used minimap preview image
 class CMultiPlayerClientMgr
 	
 	static var ^CMultiPlayerClientMgr	ms_pxInst;
@@ -136,9 +135,6 @@ class CMultiPlayerClientMgr
 			endif;
 			var ^CMirageServer pxMirageServer = m_pxPlayerListWindow^.GetMirageSettings();
 			if(pxMirageServer!=null)then
-				pxMirageServer^.OnEnableAnimalsVisInFOWEx();
-				pxMirageServer^.OnEnableAttackInFOWEx();
-				pxMirageServer^.OnEnableShowResourcesInFOWEx();
 				pxMirageServer^.OnEnablePortalsEx();
 				pxMirageServer^.OnEnableTreasureSharingEx();
 				pxMirageServer^.CheckPhantomModeEx();


### PR DESCRIPTION
- Mirage server FoW settings are not harmful if level settings fow is disabled (checked)
- Reverted because what it does is unneeded and messes up the user mirage settings config