### PR TITLE
Delete fruits disabled & deco obj not affect placecheck

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/misc/MiscObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/misc/MiscObj.usl
@@ -406,6 +406,7 @@ class CDecoObj inherit CGameObj
 		SetType("DECO");
 		SetSelectable(false);
 		SetHitable(false);
+		SetPlaceBlocker(false);
 	endproc;
 	
 endclass;
@@ -696,11 +697,12 @@ class CDecoColObj inherit CGameObj
 //	endproc;
 	
 	export proc void OnInit(bool p_bLoad)
+		SetPlaceBlocker(false);
 		super.OnInit(p_bLoad);
 		SetType("DCCO");
 		if(!p_bLoad)then
 			CSrvWrap.GetPathfinder().AddPFBlocker(this);
-			SetPlaceBlocker(true);
+			//SetPlaceBlocker(true);
 		else
 			var ^CAttribs pxA=GetAttribs();
 //			if(pxA==null)then pxA=InitAttribs(); endif;
@@ -711,10 +713,10 @@ class CDecoColObj inherit CGameObj
 				else
 					CSrvWrap.GetPathfinder().RemPFBlocker(this);
 				endif;
-				SetPlaceBlocker(bBlock);
+				//SetPlaceBlocker(bBlock);
 			else
 				CSrvWrap.GetPathfinder().AddPFBlocker(this);
-				SetPlaceBlocker(true);
+				//SetPlaceBlocker(true);
 			endif;
 		endif;
 		SetSelectable(false);

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/misc/Resource.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/misc/Resource.usl
@@ -926,9 +926,8 @@ class CFruit_Food inherit CFruitFood
 		endif;
 		super.OnInit(p_bLoad);
 		//Henry: to allow build on top of fruit brushes
-		if(CMirageSrvMgr.Get().FruitsRemovement())then
-			SetPlaceBlocker(false);
-		endif;
+		//if(CMirageSrvMgr.Get().FruitsRemovement())then
+		SetPlaceBlocker(false);
 		if(HasAnim("anim")) then
 			SetAnim("anim", 3);
 		endif;


### PR DESCRIPTION
Deleting bushes setting is no longer used. Bushes dont interrupt bldg placement, but arent deleted after bldg placement either All deco objects dont interrupt bldg placement now - experimental