### PR TITLE
seas big cannon no longer targets nests on its own

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -6693,7 +6693,7 @@ class CFightingObj inherit CGameObj
 			var ^CFightingObj pxObj=cast<CFightingObj>(p_rxList[i].GetObj());
 			if(pxObj==null)then continue; endif;
 			if(pxObj^.IsFlyingUnit()&&!m_bAirWeapon&&!m_bBUAirAttack)then continue; endif;
-			if(pxObj^.IsWildAnimal() && GetClassName()=="seas_great_cannon")then continue; endif;
+			if(!FreeHunting() && (pxObj^.IsWildAnimal() || pxObj^.GetType()=="NEST") && (GetClassName()=="seas_great_cannon"))then continue; endif;
 			if(m_bFlyingUnit&&!pxObj^.IsFlyingUnit()&&GetProjectile().IsEmpty()&&!m_bWildPtera)then continue; endif;
 			if(pxObj^.IsMarkedForDelete())then continue; endif;
 			if(pxObj^.InvalidEnemy())then continue; endif;


### PR DESCRIPTION
- seas big cannon auto fire now ignores enemies which are both wild animals and wild animal nests (can still attack them if targeted manually)
- seas big cannon only auto fires at enemy tribe objects
- TODO: Achieve this in a different way, in order for hunting command of big cannon to work (currently bugged), !FreeHunting() condition does not seem to be working for some reason