### PR TITLE
Pirate ship destruction animation

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -33,6 +33,8 @@ Maps:
 Campaign maps:
 - Amazon Warrior have female voiceover instead of male one from now on
 - Fixed floating buildings, units and incorrect camera's angles on mission 13 in three cutscenes
+- Classic Pirate ship from now on plays destruction animation of decks, once the unit being deleted. Ship decks and cannons no longer stuck in the air. Animation based on the amount, how many decks the ship had, when got order for Deletion.
+- Classis pirate ship no longer can do any actions, once all its decks being destroyed.
 
 Heroes:
 - Larry, Barry and Harry are affected by Dustriders Town Center Resource tool upgrades 1,2,3 and 4
@@ -46,6 +48,7 @@ Dustriders:
 - Town Center Resource tool upgrades 1,2,3, and 4 now correctly increase harvest speed but no longer affect build up and repair
 
 Dragon Clan:
+- Pirate ship death animation being improved. Ships decks are no logner just dissapear once the ship being killed. They are playing death animation, as well as ship's hull.
 
 Norsemen:
 
@@ -65,6 +68,8 @@ SEAS:
 - Restored SEAS laboratory crane, that was deleted long time ago
 
 AI:
+- Fixed bug, that AI were able to delete pirate ship decks separately from the main unit one by one. Now, no longer.
+- Fixed bug, that AI were able to detect pirate ship parts as attack target and kill them by splash damage, which lead to animation break up. Now, no longer.
 
 SDK:
 - Northland setting textures for icewaste vegetation added

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/Ship.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/Ship.usl
@@ -1373,13 +1373,17 @@ class CPirateBoss inherit CBigSizeShip
 	export proc void Save(^CUOFWriterNode p_pxWriterNode)
 		super.Save(p_pxWriterNode);
 		var CFourCC xBase="PiBo"; //Pirate Boss
-		var ^CUOFWriterNode pxWalk=p_pxWriterNode^.AddSubChunk(xBase,4);
+		var int iVersion=5;
+		var ^CUOFWriterNode pxWalk=p_pxWriterNode^.AddSubChunk(xBase,iVersion);
 		var ^CArc pxArc=^(pxWalk^.GetArc());
 		m_xHeck.DoKArc(pxArc^);
 		m_xSegel.DoKArc(pxArc^);
 		m_xBug.DoKArc(pxArc^);
 		m_xDummies.DoKArc(pxArc^);
 		m_xKanone.DoKArc(pxArc^);
+		if(iVersion>=5)then
+			m_xParts.DoKArc(pxArc^);
+		endif;
 		pxArc^ << m_bDeadBoat;
 		pxWalk^.Close();
 	endproc;
@@ -1500,6 +1504,9 @@ class CPirateBoss inherit CBigSizeShip
 			endif;
 			if(iVersion>=4)then
 				pxArc^ << m_bDeadBoat;
+			endif;
+			if(iVersion>=5)then
+				m_xParts.DoKArc(pxArc^);
 			endif;
 		else
 			super.Load(p_pxReaderNode);
@@ -1728,8 +1735,8 @@ class CPirateBossCorpse inherit CUniversalCorpse
 	var string		m_sGfxName;
 	var string		m_sName;
 	var real		m_fDuration;
-	var ^CGameObj	m_pxCannons;
-	var ^CGameObj	m_pxCannonsTail;
+	var CObjHndl	m_xCannons;
+	var CObjHndl	m_xCannonsTail;
 	var CObjList 	m_xParts;
 	var CObjList 	m_xDummies;
 	const string	CANNONS="pirate_boss_cannons_dest";
@@ -1739,6 +1746,36 @@ class CPirateBossCorpse inherit CUniversalCorpse
 
 	export proc void OnInit(bool p_bLoad)
 		super.OnInit(p_bLoad);
+	endproc;
+	
+	export proc void Save(^CUOFWriterNode p_pxWriterNode)
+		super.Save(p_pxWriterNode);
+		var CFourCC xBase="GCor";
+		var ^CUOFWriterNode pxWalk=p_pxWriterNode^.AddSubChunk(xBase,1);
+		var ^CArc pxArc=^(pxWalk^.GetArc());
+		pxArc^ << m_sGfxName;
+		pxArc^ << m_sName;
+		pxArc^ << m_fDuration;
+		m_xCannons.DoKArc(pxArc^);
+		m_xCannonsTail.DoKArc(pxArc^);
+		m_xParts.DoKArc(pxArc^);
+		m_xDummies.DoKArc(pxArc^);
+		pxWalk^.Close();
+	endproc;
+	
+	export proc void Load(^CUOFReaderNode p_pxReaderNode)
+		if(p_pxReaderNode^.GetType()=="GCor")then
+			var ^CArc pxArc=^(p_pxReaderNode^.GetArc());
+			pxArc^ << m_sGfxName;
+			pxArc^ << m_sName;
+			pxArc^ << m_fDuration;
+			m_xCannons.DoKArc(pxArc^);
+			m_xCannonsTail.DoKArc(pxArc^);
+			m_xParts.DoKArc(pxArc^);
+			m_xDummies.DoKArc(pxArc^);
+		else
+			super.Load(p_pxReaderNode);
+		endif;
 	endproc;
 
 	export proc bool Init(string p_sGfxName, string p_sName, real p_fDuration, CObjList p_xListA, CObjList p_xListB, bool p_bAnimateParts)
@@ -1772,21 +1809,19 @@ class CPirateBossCorpse inherit CUniversalCorpse
 				pxGameObj^.InvokeGenericSCEvent(40,4.0);
 				if(pxGameObj^.GetClassName()!=CANNONS && pxGameObj^.GetClassName()!=CANNONS_TAIL)then
 					pxPart^.PlayAnim(m_iPlayMode);
-				elseif(pxGameObj^.GetClassName()==CANNONS)then
-					m_pxCannons = pxGameObj;
-				elseif(pxGameObj^.GetClassName()==CANNONS_TAIL)then
-					m_pxCannonsTail = pxGameObj;
-				endif;
-				if(pxGameObj^.GetClassName()!=CANNONS_TAIL && pxGameObj^.GetClassName()!=CANNONS)then
 					fDuration=(pxGameObj^.GetCurrentAnimLength().ToInt()/1).ToReal();
+				elseif(pxGameObj^.GetClassName()==CANNONS)then
+					m_xCannons=pxGameObj^.GetHandle();
+				elseif(pxGameObj^.GetClassName()==CANNONS_TAIL)then
+					m_xCannonsTail=pxGameObj^.GetHandle();
 				endif;
 			endif;
 		endfor;
-		if(m_pxCannons!=null)then
+		if(m_xCannons.GetObj()!=null)then
 			CreateTimer(TIMER_DELETE_CANNONS, CGameTimeSpan.OneSecond()*4.2,false);
 		endif;
 		if(fDuration>0.0)then
-			if(m_pxCannons!=null)then
+			if(m_xCannons.GetObj()!=null)then
 				CreateTimer(TIMER_DELETE_MAIN, CGameTimeSpan.OneSecond()*(fDuration-1.4),false);
 			else
 				CreateTimer(TIMER_DELETE_MAIN, CGameTimeSpan.OneSecond()*(fDuration-3.8),false);
@@ -1810,8 +1845,8 @@ class CPirateBossCorpse inherit CUniversalCorpse
 	endproc;
 	
 	proc void DeleteCannons()
-		m_pxCannonsTail^.SetVisible(true);
-		m_pxCannons^.Delete();
+		m_xCannonsTail.GetObj()^.SetVisible(true);
+		m_xCannons.GetObj()^.Delete();
 	endproc;
 	
 	export proc void HandleEvent(ref CGameEvtPtr p_rxEvtPtr)

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/Ship.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/Ship.usl
@@ -1270,6 +1270,7 @@ endclass;
 
 class CPirateBoss inherit CBigSizeShip
 
+	const int CANNONS=836;
 	const int TIMEOUT=835;
 	const int TIMER=834;
 
@@ -1277,6 +1278,7 @@ class CPirateBoss inherit CBigSizeShip
 	var CObjHndl m_xSegel;
 	var CObjHndl m_xBug;
 	var CObjHndl m_xKanone;
+	var CObjList m_xParts;
 	var CObjList m_xDummies;
 	var bool m_bDeadBoat;
 
@@ -1304,6 +1306,9 @@ class CPirateBoss inherit CBigSizeShip
 			m_xKanone=pxCannons^.GetHandle();
 			m_bDeadBoat=false;
 		endif;
+		m_xParts.Include(m_xHeck);
+		m_xParts.Include(m_xBug);
+		m_xParts.Include(m_xSegel);
 		SetDestructionType("pirate_boss_dest","destroy");
 		DeleteTimer(TIMER);
 		CreateTimer(TIMER,CGameTimeSpan.OneSecond()*2.5,true);
@@ -1315,9 +1320,50 @@ class CPirateBoss inherit CBigSizeShip
 	endproc;
 
 	export proc ^CGameObj CreateShipCorpse()
-		var ^CShipCorpse pxGameObj=cast<CShipCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("pirate_boss_dest",GetOwner(),GetPos(),GetRotation()));
+		var CObjList xDummies;
+		var ^CPirateBossCorpse pxGameObj=cast<CPirateBossCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("pirate_boss_dest",GetOwner(),GetPos(),GetRotation()));
+		if(m_bToBeDeleted)then
+			var ^CGameObj pxPartObj;
+			var ^CPirateBossCorpse pxPart;
+			var ^CPirateBossCorpse pxCannons;
+			var vec3 vPos = m_xKanone.GetObj()^.GetPos();
+			var vec3 vRot = m_xKanone.GetObj()^.GetRotation();
+			if(m_xHeck.IsValid())then
+				pxCannons=cast<CPirateBossCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("pirate_boss_cannons_dest",GetOwner(),vPos,vRot));
+				xParts.Include(pxCannons^.GetHandle());
+				pxCannons=cast<CPirateBossCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("pirate_boss_cannons_reduced_dest",GetOwner(),vPos,vRot));
+				pxCannons^.SetVisible(false);
+				xParts.Include(pxCannons^.GetHandle());
+			else
+				pxCannons=cast<CPirateBossCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("pirate_boss_cannons_reduced_dest",GetOwner(),vPos,vRot));
+				xParts.Include(pxCannons^.GetHandle());
+			endif;
+			var int iLastAnimFrame=300;
+			var int j,jC=m_xDummies.NumEntries();
+			for(j=0)cond(j<jC)iter(j++)do
+				if(m_xDummies[j].IsValid())then
+					pxPartObj=m_xDummies[j].GetObj();
+					pxPart=cast<CPirateBossCorpse>(CSrvWrap.GetObjMgr()^.CreateObj(pxPartObj^.GetClassName(),GetOwner(),pxPartObj^.GetPos(),pxPartObj^.GetRotation()));
+					pxPart^.SetDestructLevel(2);
+					pxPart^.SetAnim("destroy",0,iLastAnimFrame);
+					pxPartObj^.Delete();
+				endif;
+			endfor;
+			var int i,iC=m_xParts.NumEntries();
+			for(i=0)cond(i<iC)iter(i++)do
+				if(m_xParts[i].IsValid())then
+					pxPartObj=m_xParts[i].GetObj();
+					pxPart=cast<CPirateBossCorpse>(CSrvWrap.GetObjMgr()^.CreateObj(pxPartObj^.GetClassName()+"_dest",GetOwner(),pxPartObj^.GetPos(),pxPartObj^.GetRotation()));
+					pxPart^.SetDestructLevel(2);
+					xDummies.Include(pxPart^.GetHandle());
+					pxPartObj^.Delete();
+				endif;
+			endfor;
+		endif;
+		m_xKanone.GetObj()^.Delete();
 		if(pxGameObj!=null)then
-			pxGameObj^.Init("pirate_boss_dest",m_sSinkAnim,GetName(), 10.0);
+			if(m_bToBeDeleted)then pxGameObj^.SetVisible(false); endif;
+			pxGameObj^.Init("pirate_boss_dest",GetName(), 17.0, xParts, xDummies, m_bToBeDeleted);
 			pxGameObj^.SetDestructLevel(2);
 		endif;
 		return pxGameObj;
@@ -1480,6 +1526,19 @@ class CPirateBoss inherit CBigSizeShip
 		return;
 	endproc;
 	
+	export proc void ReplaceCannons()
+		var ^CGameObj pxKanone=m_xKanone.GetObj();
+		if(pxKanone!=null)then
+			pxKanone^.Delete();
+		endif;
+		var ^CGameObj pxCannons=CSrvWrap.GetObjMgr()^.CreateObj("pirate_boss_cannons_reduced", GetOwner());
+		var CFourCC xLink="psh2";
+		pxCannons^.LinkAction(GetHandle(),xLink);
+		pxCannons^.SetHitable(false);
+		pxCannons^.SetSelectable(false);
+		m_xKanone=pxCannons^.GetHandle();
+	endproc;
+	
 	export proc void ReplacePart(string p_sClass, CFourCC p_xLink)
 		TerminateAction();
 		var ^CGameObj pxGameObj=CSrvWrap.GetObjMgr()^.CreateObj(p_sClass, GetOwner());
@@ -1487,26 +1546,31 @@ class CPirateBoss inherit CBigSizeShip
 		pxGameObj^.SetAnim("destroy",1);
 		var real fDuration=pxGameObj^.GetCurrentAnimLength();
 
-		if(p_sClass.Find("_tail")!=-1)then
-			var ^CGameObj pxKanone=m_xKanone.GetObj();
-			if(pxKanone!=null)then
-				pxKanone^.Delete();
-			endif;
-			var ^CGameObj pxCannons=CSrvWrap.GetObjMgr()^.CreateObj("pirate_boss_cannons_reduced", GetOwner());
-			var CFourCC xLink="psh2";
-			pxCannons^.LinkAction(GetHandle(),xLink);
-			pxCannons^.SetHitable(false);
-			pxCannons^.SetSelectable(false);
-			m_xKanone=pxCannons^.GetHandle();
+		if(p_sClass.Find("_row")!=-1)then
+			m_xBug.GetObj()^.Delete();
+			m_xBug=CObjHndl.Invalid();
+		elseif(p_sClass.Find("_sail")!=-1)then
+			m_xSegel.GetObj()^.Delete();
+			m_xSegel=CObjHndl.Invalid();
+		elseif(p_sClass.Find("_tail")!=-1)then
+			m_xHeck.GetObj()^.Delete();
+			m_xHeck=CObjHndl.Invalid();
+			CreateTimer(CANNONS,CGameTimeSpan.OneSecond()*4.2,false);
 		endif;
 
 		if(!m_xHeck.IsValid() && !m_xSegel.IsValid() && !m_xBug.IsValid())then
 			m_bDeadBoat=true;
+			StopEverything();
 		endif;
 
 		DeleteTimer(TIMEOUT);
 		CreateTimer(TIMEOUT,CGameTimeSpan.OneSecond()*fDuration,false);
 		m_xDummies.Include(pxGameObj^.GetHandle());
+	endproc;
+	
+	proc void DeleteShip()
+		m_bToBeDeleted=true;
+		Die();
 	endproc;
 
 	export proc void CheckDeath()
@@ -1518,9 +1582,6 @@ class CPirateBoss inherit CBigSizeShip
 					m_xDummies[i].GetObj()^.Delete();
 				endif;
 			endfor;
-			if(m_xKanone.IsValid())then
-				m_xKanone.GetObj()^.Delete();
-			endif;
 			Die();
 		endif;
 	endproc;
@@ -1532,11 +1593,31 @@ class CPirateBoss inherit CBigSizeShip
 				CheckDeath();
 			elseif(p_rxEvtPtr.GetInt(0)==TIMER)then
 				LogData();
+			elseif(p_rxEvtPtr.GetInt(0)==CANNONS)then
+				DeleteTimer(CANNONS);
+				ReplaceCannons();
 			else
 				super.HandleEvent(p_rxEvtPtr);
 			endif;
 		else
 			super.HandleEvent(p_rxEvtPtr);
+		endif;
+	endproc;
+	
+	export proc void ReactToGamePlayCommand(string p_sCommand, ^CGameObj p_pxObject, vec3 p_vPos, string p_sMiscParams, bool p_bQ, bool p_bS, bool p_bA)
+		if(m_bDeadBoat)then return; endif;
+		if(p_sCommand=="Kill")then
+			if(HasTimer(TIMEOUT))then return; endif;
+			DeleteShip();
+		elseif(p_sCommand=="Action")then
+			if(p_sMiscParams.Find("/Kill")!=-1)then
+				if(HasTimer(TIMEOUT))then return; endif;
+				DeleteShip();
+			else
+				super.ReactToGamePlayCommand(p_sCommand,p_pxObject,p_vPos,p_sMiscParams,p_bQ,p_bS,p_bA);
+			endif;
+		else
+			super.ReactToGamePlayCommand(p_sCommand,p_pxObject,p_vPos,p_sMiscParams,p_bQ,p_bS,p_bA);
 		endif;
 	endproc;
 
@@ -1594,9 +1675,9 @@ class CPirateBossBuildUp inherit CBuilding
 			TerminateAction();
 			var ^CPirateBoss pxBoss=cast<CPirateBoss>(m_xParent.GetObj());
 			if(pxBoss!=null)then
+				m_bBuildingReady=false;
 				pxBoss^.ReplacePart(GetClassName()+"_dest",m_xLink);
 			endif;
-			m_bBuildingReady=false;
 		endif;
 		super.Die();
 	endproc;
@@ -1640,6 +1721,120 @@ class CPirateBossCannons inherit CPirateBossBuildUp
 		return;
 	endproc;
 	
+endclass;
+
+class CPirateBossCorpse inherit CUniversalCorpse
+
+	var string		m_sGfxName;
+	var string		m_sName;
+	var real		m_fDuration;
+	var ^CGameObj	m_pxCannons;
+	var ^CGameObj	m_pxCannonsTail;
+	var CObjList 	m_xParts;
+	var CObjList 	m_xDummies;
+	const string	CANNONS="pirate_boss_cannons_dest";
+	const string	CANNONS_TAIL="pirate_boss_cannons_reduced_dest";
+	const int 		TIMER_DELETE_MAIN=837;
+	const int 		TIMER_DELETE_CANNONS=838;
+
+	export proc void OnInit(bool p_bLoad)
+		super.OnInit(p_bLoad);
+	endproc;
+
+	export proc bool Init(string p_sGfxName, string p_sName, real p_fDuration, CObjList p_xListA, CObjList p_xListB, bool p_bAnimateParts)
+		if(p_bAnimateParts)then
+			m_sGfxName = p_sGfxName;
+			m_sName = p_sName;
+			m_fDuration = p_fDuration;
+			m_xParts = p_xListA;
+			m_xDummies = p_xListB;
+			DieParts();
+		else
+			super.Init(p_sGfxName,p_sName,p_fDuration);
+		endif;
+		return(true);
+	endproc;
+
+	export proc void Init(string p_sGfxName, string p_sName, real p_fDuration)
+		super.Init(p_sGfxName,p_sName,p_fDuration);
+		return();
+	endproc;
+	
+	proc void DieParts()
+		var real fDuration=0.0;
+		var int i,iC=m_xParts.NumEntries();
+		for(i=0)cond(i<iC)iter(i++)do
+			if(m_xParts[i].IsValid())then
+				var ^CGameObj pxGameObj=m_xParts[i].GetObj();
+				var ^CPirateBossCorpse pxPart=cast<CPirateBossCorpse>(pxGameObj);
+				pxGameObj^.SetGFX(pxGameObj^.GetGfxName());
+				pxGameObj^.SetName(pxGameObj^.GetName());
+				pxGameObj^.InvokeGenericSCEvent(40,4.0);
+				if(pxGameObj^.GetClassName()!=CANNONS && pxGameObj^.GetClassName()!=CANNONS_TAIL)then
+					pxPart^.PlayAnim(m_iPlayMode);
+				elseif(pxGameObj^.GetClassName()==CANNONS)then
+					m_pxCannons = pxGameObj;
+				elseif(pxGameObj^.GetClassName()==CANNONS_TAIL)then
+					m_pxCannonsTail = pxGameObj;
+				endif;
+				if(pxGameObj^.GetClassName()!=CANNONS_TAIL && pxGameObj^.GetClassName()!=CANNONS)then
+					fDuration=(pxGameObj^.GetCurrentAnimLength().ToInt()/1).ToReal();
+				endif;
+			endif;
+		endfor;
+		if(m_pxCannons!=null)then
+			CreateTimer(TIMER_DELETE_CANNONS, CGameTimeSpan.OneSecond()*4.2,false);
+		endif;
+		if(fDuration>0.0)then
+			if(m_pxCannons!=null)then
+				CreateTimer(TIMER_DELETE_MAIN, CGameTimeSpan.OneSecond()*(fDuration-1.4),false);
+			else
+				CreateTimer(TIMER_DELETE_MAIN, CGameTimeSpan.OneSecond()*(fDuration-3.8),false);
+			endif;
+		endif;
+	endproc;
+	
+	proc void DeleteParts()
+		var int i,iC=m_xParts.NumEntries();
+		for(i=0)cond(i<iC)iter(i++)do
+			if(m_xParts[i].IsValid())then
+				m_xParts[i].GetObj()^.Delete();
+			endif;
+		endfor;
+		var int j,jC=m_xDummies.NumEntries();
+		for(j=0)cond(j<jC)iter(j++)do
+			if(m_xDummies[j].IsValid())then
+				m_xDummies[j].GetObj()^.Delete();
+			endif;
+		endfor;
+	endproc;
+	
+	proc void DeleteCannons()
+		m_pxCannonsTail^.SetVisible(true);
+		m_pxCannons^.Delete();
+	endproc;
+	
+	export proc void HandleEvent(ref CGameEvtPtr p_rxEvtPtr)
+		if(p_rxEvtPtr.GetClass() == ms_xTimerClass)then
+			var int iTimerID = p_rxEvtPtr.GetInt(0);
+			if(iTimerID == TIMER_DELETE_CANNONS)then
+				DeleteTimer(TIMER_DELETE_CANNONS);
+				DeleteCannons();
+			elseif(iTimerID == TIMER_DELETE_MAIN)then
+				DeleteTimer(TIMER_DELETE_MAIN);
+				DeleteParts();
+				SetVisible(true);
+				super.Init(m_sGfxName,m_sName,m_fDuration);
+			else
+				super.HandleEvent(p_rxEvtPtr);
+			endif;
+		endif;
+	endproc;
+
+	proc void PlayAnim(int p_iPlayMode)
+		SetAnim("destroy",1);
+	endproc;
+
 endclass;
 	
 class CTransportShip inherit CBigSizeShip

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/sl_pirate_outpost.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/sl_pirate_outpost.txt
@@ -10,7 +10,7 @@ Root {
 	}
 	pirate_boss_dest {
 		classattribs {
-			classname = 'CShipCorpse'
+			classname = 'CPirateBossCorpse'
 			gfx = 'pirate_boss_dest'
 		}
 		objectattribs {
@@ -71,9 +71,27 @@ Root {
 			tribe = 'Ninigi'
 		}
 	}
+	pirate_boss_cannons_dest {
+		classattribs {
+			classname = 'CPirateBossCorpse'
+			gfx = 'pirate_boss_cannons'
+		}
+		objectattribs {
+			tribe = 'Ninigi'
+		}
+	}
+	pirate_boss_cannons_reduced_dest {
+		classattribs {
+			classname = 'CPirateBossCorpse'
+			gfx = 'pirate_boss_cannons_reduced'
+		}
+		objectattribs {
+			tribe = 'Ninigi'
+		}
+	}
 	pirate_boss_tail_dest {
 		classattribs {
-			classname = 'CDecoObj'
+			classname = 'CPirateBossCorpse'
 			gfx = 'pirate_boss_tail_dest'
 		}
 		objectattribs {
@@ -82,7 +100,7 @@ Root {
 	}
 	pirate_boss_sail_dest {
 		classattribs {
-			classname = 'CDecoObj'
+			classname = 'CPirateBossCorpse'
 			gfx = 'pirate_boss_sail_dest'
 		}
 		objectattribs {
@@ -91,7 +109,7 @@ Root {
 	}
 	pirate_boss_row_dest {
 		classattribs {
-			classname = 'CDecoObj'
+			classname = 'CPirateBossCorpse'
 			gfx = 'pirate_boss_row_dest'
 		}
 		objectattribs {

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
@@ -8343,10 +8343,10 @@ class CPirateShipCorpse inherit CUniversalCorpse
 	var string		m_sGfxName;
 	var string		m_sName;
 	var real		m_fDuration;
-	var ^CGameObj	m_pxCannons;
-	var ^CGameObj	m_pxCannonsTail;
-	var ^CGameObj	m_pxRow;
-	var ^CGameObj	m_pxSail;
+	var CObjHndl	m_xCannons;
+	var CObjHndl	m_xCannonsTail;
+	var CObjHndl	m_xRow;
+	var CObjHndl	m_xSail;
 	var CObjList 	m_xParts;
 	const string	CANNONS="ninigi_pirate_ship_cannons_dest";
 	const string	CANNONS_TAIL="ninigi_pirate_ship_cannons_reduced_dest";
@@ -8360,6 +8360,38 @@ class CPirateShipCorpse inherit CUniversalCorpse
 
 	export proc void OnInit(bool p_bLoad)
 		super.OnInit(p_bLoad);
+	endproc;
+	
+	export proc void Save(^CUOFWriterNode p_pxWriterNode)
+		super.Save(p_pxWriterNode);
+		var CFourCC xBase="MCor";
+		var ^CUOFWriterNode pxWalk=p_pxWriterNode^.AddSubChunk(xBase,1);
+		var ^CArc pxArc=^(pxWalk^.GetArc());
+		pxArc^ << m_sGfxName;
+		pxArc^ << m_sName;
+		pxArc^ << m_fDuration;
+		m_xCannons.DoKArc(pxArc^);
+		m_xCannonsTail.DoKArc(pxArc^);
+		m_xRow.DoKArc(pxArc^);
+		m_xSail.DoKArc(pxArc^);
+		m_xParts.DoKArc(pxArc^);
+		pxWalk^.Close();
+	endproc;
+	
+	export proc void Load(^CUOFReaderNode p_pxReaderNode)
+		if(p_pxReaderNode^.GetType()=="MCor")then
+			var ^CArc pxArc=^(p_pxReaderNode^.GetArc());
+			pxArc^ << m_sGfxName;
+			pxArc^ << m_sName;
+			pxArc^ << m_fDuration;
+			m_xCannons.DoKArc(pxArc^);
+			m_xCannonsTail.DoKArc(pxArc^);
+			m_xRow.DoKArc(pxArc^);
+			m_xSail.DoKArc(pxArc^);
+			m_xParts.DoKArc(pxArc^);
+		else
+			super.Load(p_pxReaderNode);
+		endif;
 	endproc;
 
 	export proc bool Init(string p_sGfxName, string p_sName, real p_fDuration, CObjList p_xList)
@@ -8390,13 +8422,13 @@ class CPirateShipCorpse inherit CUniversalCorpse
 					pxPart^.PlayAnim(m_iPlayMode);
 					fDuration=(pxGameObj^.GetCurrentAnimLength().ToInt()/1).ToReal();
 				elseif(pxGameObj^.GetClassName()==SHIP_SAIL)then
-					m_pxSail = pxGameObj;
+					m_xSail=pxGameObj^.GetHandle();
 				elseif(pxGameObj^.GetClassName()==SHIP_ROW)then
-					m_pxRow = pxGameObj;
+					m_xRow=pxGameObj^.GetHandle();
 				elseif(pxGameObj^.GetClassName()==CANNONS)then
-					m_pxCannons = pxGameObj;
+					m_xCannons=pxGameObj^.GetHandle();
 				elseif(pxGameObj^.GetClassName()==CANNONS_TAIL)then
-					m_pxCannonsTail = pxGameObj;
+					m_xCannonsTail=pxGameObj^.GetHandle();
 				endif;
 			endif;
 		endfor;
@@ -8409,18 +8441,18 @@ class CPirateShipCorpse inherit CUniversalCorpse
 	endproc;
 	
 	proc void DieSail()
-		var ^CPirateShipCorpse pxPart=cast<CPirateShipCorpse>(m_pxSail);
-		m_pxSail^.SetGFX(m_pxSail^.GetGfxName());
-		m_pxSail^.SetName(m_pxSail^.GetName());
-		m_pxSail^.InvokeGenericSCEvent(40,4.0);
+		var ^CPirateShipCorpse pxPart=cast<CPirateShipCorpse>(m_xSail.GetObj());
+		pxPart^.SetGFX(pxPart^.GetGfxName());
+		pxPart^.SetName(pxPart^.GetName());
+		pxPart^.InvokeGenericSCEvent(40,4.0);
 		pxPart^.PlayAnim(m_iPlayMode);
 	endproc;
 	
 	proc void DieRow()
-		var ^CPirateShipCorpse pxPart=cast<CPirateShipCorpse>(m_pxRow);
-		m_pxRow^.SetGFX(m_pxRow^.GetGfxName());
-		m_pxRow^.SetName(m_pxRow^.GetName());
-		m_pxRow^.InvokeGenericSCEvent(40,4.0);
+		var ^CPirateShipCorpse pxPart=cast<CPirateShipCorpse>(m_xRow.GetObj());
+		pxPart^.SetGFX(pxPart^.GetGfxName());
+		pxPart^.SetName(pxPart^.GetName());
+		pxPart^.InvokeGenericSCEvent(40,4.0);
 		pxPart^.PlayAnim(m_iPlayMode);
 	endproc;
 	
@@ -8434,8 +8466,8 @@ class CPirateShipCorpse inherit CUniversalCorpse
 	endproc;
 	
 	proc void DeleteCannons()
-		m_pxCannonsTail^.SetVisible(true);
-		m_pxCannons^.Delete();
+		m_xCannonsTail.GetObj()^.SetVisible(true);
+		m_xCannons.GetObj()^.Delete();
 	endproc;
 	
 	export proc void HandleEvent(ref CGameEvtPtr p_rxEvtPtr)

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
@@ -7733,6 +7733,7 @@ class CPirateShip inherit CBigSizeShip
 	
 	export proc void Die()
 		if(!IsDead())then
+			CreateShipCorpse();
 			if(m_xKanone.IsValid())then
 				RemGroupedChildren(m_xKanone.GetObj()^.GetGuid());
 				m_xKanone.GetObj()^.Delete();
@@ -7757,15 +7758,32 @@ class CPirateShip inherit CBigSizeShip
 			m_xBug=CObjHndl.Invalid();
 			m_xKanone=CObjHndl.Invalid();
 			*/
-			CreateShipCorpse();
 		endif;
 		super.Die();
 	endproc;
 	
 	export proc ^CGameObj CreateShipCorpse()
-		var ^CShipCorpse pxGameObj=cast<CShipCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_ship_dest",GetOwner(),GetPos(),GetRotation()));
+		var CObjList xDummies;
+		var ^CPirateShipCorpse pxPart;
+		var ^CPirateShipCorpse pxCannons;
+		var ^CPirateShipCorpse pxGameObj=cast<CPirateShipCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_ship_dest",GetOwner(),GetPos(),GetRotation()));
+		var int i,iC=m_xParts.NumEntries();
+		for(i=0)cond(i<iC)iter(i++)do
+			var ^CGameObj pxPartObj=m_xParts[i].GetObj();
+			pxPart=cast<CPirateShipCorpse>(CSrvWrap.GetObjMgr()^.CreateObj(pxPartObj^.GetClassName()+"_dest",GetOwner(),pxPartObj^.GetPos(),pxPartObj^.GetRotation()));
+			pxPart^.SetDestructLevel(2);
+			xDummies.Include(pxPart^.GetHandle());
+		endfor;
+		var vec3 vPos = m_xKanone.GetObj()^.GetPos();
+		var vec3 vRot = m_xKanone.GetObj()^.GetRotation();
+		pxCannons=cast<CPirateShipCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_ship_cannons_dest",GetOwner(),vPos,vRot));
+		xDummies.Include(pxCannons^.GetHandle());
+		pxCannons=cast<CPirateShipCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_ship_cannons_reduced_dest",GetOwner(),vPos,vRot));
+		pxCannons^.SetVisible(false);
+		xDummies.Include(pxCannons^.GetHandle());
 		if(pxGameObj!=null)then
-			pxGameObj^.Init("ninigi_pirate_ship_dest",m_sSinkAnim,GetName(), 10.0);
+			pxGameObj^.SetVisible(false);
+			pxGameObj^.Init("ninigi_pirate_ship_dest",GetName(), 17.0, xDummies);
 			pxGameObj^.SetDestructLevel(2);
 		endif;
 		return pxGameObj;
@@ -8212,7 +8230,7 @@ class CPirateShipBuildUp inherit CFightingObj
 	endproc;
 	
 	export proc void Die()
-		if(!IsDead())then
+/*		if(!IsDead())then
 			var ^CGameObj pxParent = m_xParent.GetObj();
 			if(pxParent!=null)then
 				pxParent^.RemGroupedChildren(GetGuid());
@@ -8222,7 +8240,8 @@ class CPirateShipBuildUp inherit CFightingObj
 			pxBoss^.ReplacePart(GetClassName()+"_dest",m_xLink);
 //			m_bBuildingReady=false;
 		endif;
-		super.Die();
+		super.Die();	*/
+		return;
 	endproc;
 	
 	export proc void ReactToGamePlayCommand(string p_sCommand, ^CGameObj p_pxObject, vec3 p_vPos, string p_sMiscParams, bool p_bQ, bool p_bS, bool p_bA)
@@ -8235,12 +8254,14 @@ class CPirateShipBuildUp inherit CFightingObj
 			endif;
 		endif;
 		if(GetIncapacitated()&&(p_sMiscParams.Find("/Kill")!=-1||p_sCommand=="Kill")&&!(p_sCommand=="Cancel"))then return; endif;
-		if(p_sCommand=="Delete")then
-			Delete();
+		if(p_sCommand=="Delete"||p_sCommand=="Kill")then
+			return;
 		elseif(p_sCommand=="Action")then
 			if(p_sMiscParams.Find("/Attack")==-1&&p_sMiscParams.Find("/GoAway")==-1&&p_sMiscParams.Find("/AttackSrv")==-1&&p_sMiscParams.Find("/Walk")==-1 
 				&& p_sMiscParams.Find("/Stop")==-1&&p_sMiscParams.Find("/LevelUp")==-1&&p_sMiscParams.Find("/AggressiveTarget")==-1&&p_sMiscParams.Find("/AggroState_")==-1)then
 				super.ReactToGamePlayCommand(p_sCommand,p_pxObject,p_vPos,p_sMiscParams,p_bQ,p_bS,p_bA);
+			elseif(p_sMiscParams.Find("/Kill")!=-1)then
+				return;
 			else
 				if(bShip)then
 					pxShip^.ReactToGamePlayCommand(p_sCommand, p_pxObject, p_vPos, p_sMiscParams, p_bQ, p_bS, p_bA);
@@ -8315,6 +8336,135 @@ class CPirateShipCannons inherit CPirateShipBuildUp
 		return "";
 	endproc;
 	
+endclass;
+
+class CPirateShipCorpse inherit CUniversalCorpse
+
+	var string		m_sGfxName;
+	var string		m_sName;
+	var real		m_fDuration;
+	var ^CGameObj	m_pxCannons;
+	var ^CGameObj	m_pxCannonsTail;
+	var ^CGameObj	m_pxRow;
+	var ^CGameObj	m_pxSail;
+	var CObjList 	m_xParts;
+	const string	CANNONS="ninigi_pirate_ship_cannons_dest";
+	const string	CANNONS_TAIL="ninigi_pirate_ship_cannons_reduced_dest";
+	const string	SHIP_TAIL="ninigi_pirate_ship_tail_dest";
+	const string	SHIP_SAIL="ninigi_pirate_ship_sail_dest";
+	const string	SHIP_ROW="ninigi_pirate_ship_row_dest";
+	const int 		TIMER_DELETE_MAIN=40037;
+	const int 		TIMER_DELETE_CANNONS=40038;
+	const int 		TIMER_PLAY_SAIL=40039;
+	const int 		TIMER_PLAY_ROW=40040;
+
+	export proc void OnInit(bool p_bLoad)
+		super.OnInit(p_bLoad);
+	endproc;
+
+	export proc bool Init(string p_sGfxName, string p_sName, real p_fDuration, CObjList p_xList)
+		m_sGfxName = p_sGfxName;
+		m_sName = p_sName;
+		m_fDuration = p_fDuration;
+		m_xParts = p_xList;
+		DieTail();
+		return(true);
+	endproc;
+
+	export proc void Init(string p_sGfxName, string p_sName, real p_fDuration)
+		super.Init(p_sGfxName,p_sName,p_fDuration);
+		return();
+	endproc;
+	
+	proc void DieTail()
+		var real fDuration=0.0;
+		var int i,iC=m_xParts.NumEntries();
+		for(i=0)cond(i<iC)iter(i++)do
+			if(m_xParts[i].IsValid())then
+				var ^CGameObj pxGameObj=m_xParts[i].GetObj();
+				if(pxGameObj^.GetClassName()==SHIP_TAIL)then
+					var ^CPirateShipCorpse pxPart=cast<CPirateShipCorpse>(pxGameObj);
+					pxGameObj^.SetGFX(pxGameObj^.GetGfxName());
+					pxGameObj^.SetName(pxGameObj^.GetName());
+					pxGameObj^.InvokeGenericSCEvent(40,4.0);
+					pxPart^.PlayAnim(m_iPlayMode);
+					fDuration=(pxGameObj^.GetCurrentAnimLength().ToInt()/1).ToReal();
+				elseif(pxGameObj^.GetClassName()==SHIP_SAIL)then
+					m_pxSail = pxGameObj;
+				elseif(pxGameObj^.GetClassName()==SHIP_ROW)then
+					m_pxRow = pxGameObj;
+				elseif(pxGameObj^.GetClassName()==CANNONS)then
+					m_pxCannons = pxGameObj;
+				elseif(pxGameObj^.GetClassName()==CANNONS_TAIL)then
+					m_pxCannonsTail = pxGameObj;
+				endif;
+			endif;
+		endfor;
+		CreateTimer(TIMER_PLAY_SAIL, CGameTimeSpan.OneSecond()*2.15,false);
+		CreateTimer(TIMER_PLAY_ROW, CGameTimeSpan.OneSecond()*1.33,false);
+		CreateTimer(TIMER_DELETE_CANNONS, CGameTimeSpan.OneSecond()*4.2,false);
+		if(fDuration>0.0)then
+			CreateTimer(TIMER_DELETE_MAIN, CGameTimeSpan.OneSecond()*(fDuration-5.0),false);
+		endif;
+	endproc;
+	
+	proc void DieSail()
+		var ^CPirateShipCorpse pxPart=cast<CPirateShipCorpse>(m_pxSail);
+		m_pxSail^.SetGFX(m_pxSail^.GetGfxName());
+		m_pxSail^.SetName(m_pxSail^.GetName());
+		m_pxSail^.InvokeGenericSCEvent(40,4.0);
+		pxPart^.PlayAnim(m_iPlayMode);
+	endproc;
+	
+	proc void DieRow()
+		var ^CPirateShipCorpse pxPart=cast<CPirateShipCorpse>(m_pxRow);
+		m_pxRow^.SetGFX(m_pxRow^.GetGfxName());
+		m_pxRow^.SetName(m_pxRow^.GetName());
+		m_pxRow^.InvokeGenericSCEvent(40,4.0);
+		pxPart^.PlayAnim(m_iPlayMode);
+	endproc;
+	
+	proc void DeleteParts()
+		var int i,iC=m_xParts.NumEntries();
+		for(i=0)cond(i<iC)iter(i++)do
+			if(m_xParts[i].IsValid())then
+				m_xParts[i].GetObj()^.Delete();
+			endif;
+		endfor;
+	endproc;
+	
+	proc void DeleteCannons()
+		m_pxCannonsTail^.SetVisible(true);
+		m_pxCannons^.Delete();
+	endproc;
+	
+	export proc void HandleEvent(ref CGameEvtPtr p_rxEvtPtr)
+		if(p_rxEvtPtr.GetClass() == ms_xTimerClass)then
+			var int iTimerID = p_rxEvtPtr.GetInt(0);
+			if(iTimerID == TIMER_PLAY_ROW)then
+				DeleteTimer(TIMER_PLAY_ROW);
+				DieRow();
+			elseif(iTimerID == TIMER_PLAY_SAIL)then
+				DeleteTimer(TIMER_PLAY_SAIL);
+				DieSail();
+			elseif(iTimerID == TIMER_DELETE_CANNONS)then
+				DeleteTimer(TIMER_DELETE_CANNONS);
+				DeleteCannons();
+			elseif(iTimerID == TIMER_DELETE_MAIN)then
+				DeleteTimer(TIMER_DELETE_MAIN);
+				DeleteParts();
+				SetVisible(true);
+				super.Init(m_sGfxName,m_sName,m_fDuration);
+			else
+				super.HandleEvent(p_rxEvtPtr);
+			endif;
+		endif;
+	endproc;
+
+	proc void PlayAnim(int p_iPlayMode)
+		SetAnim("destroy",1);
+	endproc;
+
 endclass;
 	
 	//========================================================================================

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/mirage_buildings.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/mirage_buildings.txt
@@ -173,7 +173,7 @@ Root {
 	}
 	ninigi_pirate_ship_dest {
 		classattribs {
-			classname = 'CShipCorpse'
+			classname = 'CPirateShipCorpse'
 			gfx = 'pirate_boss_dest'
 		}
 		objectattribs {
@@ -252,9 +252,27 @@ Root {
 			tribe = 'Ninigi'
 		}
 	}
+	ninigi_pirate_ship_cannons_dest {
+		classattribs {
+			classname = 'CPirateShipCorpse'
+			gfx = 'pirate_boss_cannons'
+		}
+		objectattribs {
+			tribe = 'Ninigi'
+		}
+	}
+	ninigi_pirate_ship_cannons_reduced_dest {
+		classattribs {
+			classname = 'CPirateShipCorpse'
+			gfx = 'pirate_boss_cannons_reduced'
+		}
+		objectattribs {
+			tribe = 'Ninigi'
+		}
+	}
 	ninigi_pirate_ship_tail_dest {
 		classattribs {
-			classname = 'CDecoObj'
+			classname = 'CPirateShipCorpse'
 			gfx = 'pirate_boss_tail_dest'
 		}
 		objectattribs {
@@ -263,7 +281,7 @@ Root {
 	}
 	ninigi_pirate_ship_sail_dest {
 		classattribs {
-			classname = 'CDecoObj'
+			classname = 'CPirateShipCorpse'
 			gfx = 'pirate_boss_sail_dest'
 		}
 		objectattribs {
@@ -272,7 +290,7 @@ Root {
 	}
 	ninigi_pirate_ship_row_dest {
 		classattribs {
-			classname = 'CDecoObj'
+			classname = 'CPirateShipCorpse'
 			gfx = 'pirate_boss_row_dest'
 		}
 		objectattribs {


### PR DESCRIPTION
Fixed:
- Fixed both for the cmapaign and playable unit, that pirate ship's Hull animation were ending too early, so the ship wrecks didnt fully sank in the sea and were just dissapearing on sea's surface.
- The AI no longer able to delete parts of playable PirateShip separately, only altogether with unit itself
- Playble pirate ship decks are inveruable and cannot die on its own, until the ship stays alive
- The campaign Pirate Ship are no longer react to any gameplay commands once all decks being destroyed
- Once the campaign ship deleted, the ship decks and cannons are no longer stuck in the air
Added:
- The playble pirate ship from now on has destruction animation of all decks, instead of them being just dissapearing on unit death
- The campaign ship, if being deleted by player or AI from now on play's destruction animation, which depends on how many decks the ship had, when got an order for being Deleted