### PR TITLE
AmazonTemple unbuilded death animation fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
@@ -8506,6 +8506,7 @@ endclass;
 class CAjeAmazonTemple inherit CTemple
 	
 	export proc bool CreateBuildingCorpse()
+		if(!m_bBuildingReady)then return false; endif;
 		if(GetGfxName()=="amazon_temple")then
 			var ^CAjeAmazonTempleCorpse pxGameObj = cast<CAjeAmazonTempleCorpse>(CSrvWrap.GetObjMgr()^.CreateObj("aje_amazon_temple_corpse",GetOwner(),GetPos(),GetRotation()));
 			if(pxGameObj!=null)then


### PR DESCRIPTION
- Fixed animation, when Amazon Temple were killed/deleted until the buiild sequence was completed