### PR TITLE
Multi cannon spawn fix for seas_great_cannon

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
@@ -10263,11 +10263,13 @@ class CSeasGreatCannon inherit CTower
 				SetTurret("seas_great_cannon_rotator");
 				m_sTurretAttackAnim="attack_front";
 			endif;
-			var ^CGameObj pxO=CSrvWrap.GetObjMgr()^.CreateObj("seas_great_cannon_cannon", GetOwner());
-			AddGroupedChildren(pxO^.GetGuid());
-			var CFourCC xLink="we";
-			pxO^.LinkAction(m_xTurret,xLink);
-			m_xBirdie=pxO^.GetHandle();
+			if(!m_xBirdie.IsValid())then
+				var ^CGameObj pxO=CSrvWrap.GetObjMgr()^.CreateObj("seas_great_cannon_cannon", GetOwner());
+				AddGroupedChildren(pxO^.GetGuid());
+				var CFourCC xLink="we";
+				pxO^.LinkAction(m_xTurret,xLink);
+				m_xBirdie=pxO^.GetHandle();
+			endif;
 		endif;
 		//ParaworldFan end
 /*		var string sPlayerName="";


### PR DESCRIPTION
Fixed issue, when during each time saving the map, game was generating a new object "seas_great_cannon" even if the previous one was already exist.

To fix issues on the maps, required to remove duplicates on all maps which were saved after that issue appeared. Better to delete whole unit and place on map again.