### PR TITLE
Hotfixes in USL & TechTree & config files

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Locale/cz/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/cz/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -362,6 +362,21 @@ There are also a few more special \{ref H_general.seml#_units} units\{/ref} whic
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Defensive buildings}
 \{helpitem -name _ninigi_spike_trap Spike trap}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/Locale/de/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/de/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -364,6 +364,21 @@ Die anderen Spezialeinheiten stehen nur zur Verfügung, wenn ein bestimmter \{re
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Verteidigungsgebäude}
 \{helpitem -name _ninigi_spike_trap Stachelfalle}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/Locale/fr/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/fr/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -365,6 +365,21 @@ Certaines \{ref H_general.seml#_units}unités\{/ref} spéciales ne deviennent di
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Defensive buildings}
 \{helpitem -name _ninigi_spike_trap Fosse à épieux}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/Locale/hu/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/hu/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -401,6 +401,21 @@ There are also a few more special \{ref H_general.seml#_units} units\{/ref} whic
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Védelmi épületek}
 \{helpitem -name _ninigi_spike_trap Tüskecsapda}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/Locale/it/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/it/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -368,6 +368,21 @@ VI sono anche \{ref H_general.seml#_units} unità \{/ref} speciali, disponibili 
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Edifici difensivi}
 \{helpitem -name _ninigi_spike_trap Trappola appuntita}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/Locale/pl/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/pl/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -360,6 +360,21 @@ W budynku tym można wyprodukować także inne specjalne \{ref H_general.seml#_u
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Budynki obronne}
 \{helpitem -name _ninigi_spike_trap Pułapka z kolcami}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/Locale/ru/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/ru/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -352,6 +352,21 @@
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Ремонтный док}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Строит главный пиратский корабль
+   \{/tooltipmedium}
+   \{tooltiplong}
+Ранее принадлежавший Пиратам, когда-то наводивший ужас в океанах, \{ref H_special_location.seml#_pirate_boss_row}огромный корабль \{/ref} был уничтожен \{ref H_general.seml#_heros}троицей героев \{/ref} , а его обломки затонули недалеко от Пиратской деревни. \\{br}
+После поражения Пиратов обломки корабля были найдены и пришвартованы к берегу всемогущим \{ref H_story.seml#_story_ninigi}племенем Клана Дракона\{/ref}.
+Они построили сухой док и реконструировали морского гиганта для использования в своих целях.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Защитные строения}
 \{helpitem -name _ninigi_spike_trap Ловушка с шипами}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/Locale/uk/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/uk/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -362,6 +362,21 @@ There are also a few more special \{ref H_general.seml#_units} units\{/ref} whic
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Defensive buildings}
 \{helpitem -name _ninigi_spike_trap Spike trap}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/Locale/zh/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/zh/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -347,6 +347,21 @@
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings 防御类建筑}
 \{helpitem -name _ninigi_spike_trap 钉刺陷阱}
 \{img /bunit:ninigi_spike_trap -ralign}

--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -13,7 +13,7 @@ General:
 - Empty sub-menus in the command bar are now hidden
 - All menus are centered now (can be reverted by disabling "center menu" checkbox in the options menu)
 - New game-mechanics server setting added: "Ally controll" - if enabled you can control your ally's units, and they can control yours
-- Improved cutscenes for Boosterpack1 singleplayer campaign for classis and SEAS versions
+- Improved cutscenes for Boosterpack1 singleplayer campaign for classic and SEAS versions
 - Holy city gates on skirmish maps and in mission 13 are playing "Open" animation from now on
 - Pirate ship chain on skirmish maps and in mission 6 are playing "Open" & "Close" animation from now on
 - Fixed bug with Holy City gates destruction animation wasnt playing
@@ -67,6 +67,7 @@ Dragon Clan:
 
 Norsemen:
 - Stone Guardian is buildable as a separate structure (like a seas scorpion)
+- Stone Guardian from now on has destruction stages. If it has low hitpoints left, it loses it's head.
 - Producing Stone Guardian in Machine Maker as unit no longer available
 - Harbour placing ghost from now on has missing crane displaying
 - Fixed broken warpgate model
@@ -91,21 +92,25 @@ SEAS:
 - Improved big cannon build sequnece. The base platform are not placed by default, it appears during construction process, as well as the rotator.
 - Buildable and campaign big cannon from on have destruction stages
 - Fixed bug, where not fully built big cannon were playing destruction animation, if it was killed
-- Fixed bug when death animation being played, when the pub or laboratory being not fully built while were killed
+- Fixed bug when death animation being played, while pub or laboratory being not fully built and were killed
+- Fixed bug, when seas poison ammo upgrade wasnt applied to playable babbage mobile suit, if "Free Specials" server option was enabled
+- Fixed bug of disabled build icon for scorpion wasnt displaying properly if "Supply system" were enabled on the server
 - Added SEAS laboratory work animation, that plays when building produces unit or research upgrade
 - Restored SEAS laboratory crane, that was deleted long time ago
 
 AI:
-- Fixed bug, that AI were able to delete pirate ship decks separately from the main unit one by one. Now, no longer.
-- Fixed bug, that AI were able to detect pirate ship parts as attack target and kill them by splash damage, which lead to animation break up. Now, no longer.
+- Fixed bug, where AI were able to delete pirate ship decks separately from the main unit one by one. Now, no longer.
+- Fixed bug, where AI were able to detect pirate ship parts as attack target and kill them by splash damage, which lead to animation break up. Now, no longer.
 - AI from now on able to convert Babbage hero to the Mobile Suit as SEAS tribe
 - AI from now on able to use defensive mode for norsemen common, jetpack and zombie warriors
-- AI from now on ablet construct Stone Statue as building
+- AI from now on able to construct Stone Statue as building
+- AI from now on able to construct The Main Pirate ship as building
 
 SDK:
 - Level terrain can be saved as .obj mesh with "Export to .obj" button at icons bar
 - Northland setting textures for icewaste vegetation added
 - Fixed seas_great_cannon placing
+- Fixed seas_final_boss level placing. ALways placed on level 5 by default now.
 
 MIRAGE 2.6.6
 ------------------

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Ai/goals/AiGoalBuildVillage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Ai/goals/AiGoalBuildVillage.usl
@@ -920,8 +920,9 @@ class CAiGoalBuildVillage inherit CAiGoal
 				endif;
 			endif;
 		elseif(m_sTribe=="Ninigi")then
-//			if(m_bFinalStage)then
-//			endif;
+			if(m_bFinalStage)then
+				AddRequestOnTop("BLDG/ninigi_launchpad_pirate_boss",1,true);
+			endif;
 			var bool bSupply=CMirageAIMgr.Get().AllowSupplySystem();
 			AddRequest("BLDG/ninigi_fireplace",3,true);
 			if(m_bHarbour)then

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
@@ -4352,22 +4352,30 @@ class CHuAvatar inherit CVehicle
 		endif;
 	endproc;
 	
+	proc bool UpdateDestructionFlags()
+		if(((GetHitpoints()!=0.0f)&&(GetMaxHitpoints()!=0.0f)))then
+			var real fPercentage=GetHitpoints()/(GetMaxHitpoints()/100.0f);
+			if(fPercentage<=25.0f)then
+				SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_HEAD,false);
+			elseif(fPercentage<=50.0f)then
+				SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_HEAD,true);
+			endif;
+		endif;
+		return true;
+	endproc;
+	
 endclass;
 
 class CHuAvatarLaunchpad inherit CBuilding
 
 	var bool 		m_bActive;
 	var bool 		m_bFirstStage;
-	var bool 		m_bSecondStage;
-	var bool 		m_bThirdStage;
 	var bool 		m_bFinalStage;
 	var CObjHndl 	m_xBuildDeco;
 	
 	export constructor()
 		m_bActive=false;
 		m_bFirstStage=false;
-		m_bSecondStage=false;
-		m_bThirdStage=false;
 		m_bFinalStage=false;
 	endconstructor;
 	
@@ -4378,8 +4386,6 @@ class CHuAvatarLaunchpad inherit CBuilding
 			if(iVersion>=1)then
 				pxArc^<<m_bActive;
 				pxArc^<<m_bFirstStage;
-				pxArc^<<m_bSecondStage;
-				pxArc^<<m_bThirdStage;
 				pxArc^<<m_bFinalStage;
 				m_xBuildDeco.DoKArc(pxArc^);
 			endif;
@@ -4395,8 +4401,6 @@ class CHuAvatarLaunchpad inherit CBuilding
 		var ^CArc pxArc=^(pxWalk^.GetArc());
 		pxArc^ << m_bActive;
 		pxArc^<<m_bFirstStage;
-		pxArc^<<m_bSecondStage;
-		pxArc^<<m_bThirdStage;
 		pxArc^<<m_bFinalStage;
 		m_xBuildDeco.DoKArc(pxArc^);
 		pxWalk^.Close();
@@ -4410,10 +4414,9 @@ class CHuAvatarLaunchpad inherit CBuilding
 		if(!p_bLoad)then
 			if(!CMirageSrvMgr.SDK())then
 				var ^CMirageDeco pxO=cast<CMirageDeco>(CSrvWrap.GetObjMgr()^.CreateObj("hu_colossi_launchpad_misc_0",GetOwner(),GetPos(),GetRotation()));
-				pxO^.SetVisible(false);
 				pxO^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_HEAD,false);
-				pxO^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_BODY,false);
-				pxO^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_LEGS,false);
+				pxO^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_BODY,false);	//arms
+				pxO^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_LEGS,false);	//weapon
 				AddGroupedChildren(pxO^.GetGuid());
 				var CFourCC xLink="NONE";
 				pxO^.LinkAction(GetHandle(),xLink,{0.0,0.0,0.0});
@@ -4440,18 +4443,12 @@ class CHuAvatarLaunchpad inherit CBuilding
 	
 	export proc void SetProcess(int p_iP)
 		super.SetProcess(p_iP);
-		if(p_iP==26 && !m_bFirstStage)then
+		if(p_iP==51 && !m_bFirstStage)then
 			m_bFirstStage=true;
-			m_xBuildDeco.GetObj()^.SetVisible(true);
-		elseif(p_iP==51 && !m_bSecondStage)then
-			m_bSecondStage=true;
 			m_xBuildDeco.GetObj()^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_BODY,true);	//arms
-		elseif(p_iP==76 && !m_bThirdStage)then
-			m_bThirdStage=true;
-			m_xBuildDeco.GetObj()^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_HEAD,true);
-		elseif(p_iP==95 && !m_bFinalStage)then
+		elseif(p_iP==76 && !m_bFinalStage)then
 			m_bFinalStage=true;
-			m_xBuildDeco.GetObj()^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_LEGS,true);	//weapon
+			m_xBuildDeco.GetObj()^.SetRndInvMaskSingleFlagInv(VIS_FLAG_CHTR_HEAD,true);
 		endif;
 	endproc;
 	
@@ -4506,6 +4503,10 @@ class CHuAvatarLaunchpad inherit CBuilding
 	
 	proc bool UpdateDestructionFlags()
 		return false;
+	endproc;
+	
+	export proc void CreateCorpse()
+		return;
 	endproc;
 	
 	export proc bool CreateBuildingCorpse()
@@ -10459,7 +10460,7 @@ class CSeasGreatCannon inherit CTower
 				m_xBirdie=pxO^.GetHandle();
 			endif;
 		endif;
-		//ParaworldFan end
+		//
 /*		var string sPlayerName="";
 		var ^CLevel pxLevel=CSrvWrap.GetCurLevel();
 		if(pxLevel!=null)then
@@ -11232,11 +11233,11 @@ endclass;
 
 class CNinigiPirateBossLaunchpad inherit CBuilding
 		
-	var bool m_bActive;
+	var bool 		m_bActive;
 	//These booleans needed, so the functions inside SetProcess(int p_iP) wont be called multiple times
-	var bool m_bParts;
-	var bool m_bFirstStage;
-	var bool m_bSecondStage;
+	var bool 		m_bParts;
+	var bool 		m_bFirstStage;
+	var bool 		m_bSecondStage;
 	var CObjList 	m_xDummies;
 	
 	export constructor()
@@ -11287,18 +11288,25 @@ class CNinigiPirateBossLaunchpad inherit CBuilding
 			var CFourCC xLink="Bl_1";
 			GetLinkPosRotWorld(xLink,vPos,qRot);
 			qRot.ToVec3(vRot);
-			xLink="NONE";
-			var ^CMirageDeco pxGameObj=cast<CMirageDeco>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_ship_deco_0",GetOwner(),vPos,vRot));
-			pxGameObj^.LinkAction(GetHandle(),xLink,vPos-GetPos());
-			AddGroupedChildren(pxGameObj^.GetGuid());
-			m_xDummies.Include(pxGameObj^.GetHandle());
-		endif;
-	endproc;
-	
-	//This function makes building always with 1 HP and always Not Builded, if Placed through SDK
-	export proc void OnPostLoad()
-		if(!CSrvWrap.GetCurLevel()^.IsEditable() && !IsReady()&&GetCurTaskName()!="BuildUpB")then
-			BuildUp("/Actions/"+GetTribeName()+"/Build/BLDG/"+GetClassName());
+			if(!CMirageSrvMgr.SDK())then
+				xLink="NONE";
+				var ^CMirageDeco pxGameObj=cast<CMirageDeco>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_ship_deco_0",GetOwner(),vPos,vRot));
+				pxGameObj^.LinkAction(GetHandle(),xLink,vPos-GetPos());
+				AddGroupedChildren(pxGameObj^.GetGuid());
+				m_xDummies.Include(pxGameObj^.GetHandle());
+			else
+				var ^CPirateShip pxShip=cast<CPirateShip>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_boss_ship",GetOwner(),vPos,vRot));
+				if(pxShip!=null)then
+					var ^CAttribs pxAttr=pxShip^.GetAttribs();
+					if(pxAttr!=null)then
+						pxAttr^.SetValue("clientpyramid_replacecard", GetName());
+					endif;
+					pxShip^.SetLevelClean(4);
+					pxShip^.SetIdleAnim();
+					pxShip^.ExamineEnemies(false);
+					Delete();
+				endif;
+			endif;
 		endif;
 	endproc;
 	
@@ -11359,39 +11367,39 @@ class CNinigiPirateBossLaunchpad inherit CBuilding
 	endproc;
 	
 	export proc void SetReady()
-		SetVisible(false);
 		super.SetReady();
-		if(m_bBuildingReady)then
-			var string sGFX=m_xTechTree.GetValueS(GetObjPath()+"/gfx","");
-			if(!sGFX.IsEmpty()&&sGFX!=GetGfxName())then
-				super.SetGFX(sGFX);
+		if(!CMirageSrvMgr.SDK())then
+			SetVisible(false);
+			if(m_bBuildingReady)then
+				var string sGFX=m_xTechTree.GetValueS(GetObjPath()+"/gfx","");
+				if(!sGFX.IsEmpty()&&sGFX!=GetGfxName())then
+					super.SetGFX(sGFX);
+				endif;
 			endif;
-		endif;
-		if(m_bActive)then return; endif;
-		m_bActive=true;
-		SetSelectable(false);
-		SetHitable(false);
-		//
-		var vec3 vPos=m_xDummies[2].GetObj()^.GetPos();
-		var vec3 vRot=m_xDummies[2].GetObj()^.GetRotation();
-		var int i, iC=m_xDummies.NumEntries();
-		for(i=0)cond(i<iC)iter(i++)do
-			if(m_xDummies[i].IsValid())then
-				RemGroupedChildren(m_xDummies[i].GetObj()^.GetGuid());
-				m_xDummies[i].GetObj()^.Delete();
+			if(m_bActive)then return; endif;
+			m_bActive=true;
+			SetSelectable(false);
+			SetHitable(false);
+			var vec3 vPos=m_xDummies[2].GetObj()^.GetPos();
+			var vec3 vRot=m_xDummies[2].GetObj()^.GetRotation();
+			var int i, iC=m_xDummies.NumEntries();
+			for(i=0)cond(i<iC)iter(i++)do
+				if(m_xDummies[i].IsValid())then
+					RemGroupedChildren(m_xDummies[i].GetObj()^.GetGuid());
+					m_xDummies[i].GetObj()^.Delete();
+				endif;
+			endfor;
+			var ^CPirateShip pxShip=cast<CPirateShip>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_boss_ship",GetOwner(),vPos,vRot));
+			if(pxShip!=null)then
+				var ^CAttribs pxAttr=pxShip^.GetAttribs();
+				if(pxAttr!=null)then
+					pxAttr^.SetValue("clientpyramid_replacecard", GetName());
+				endif;
+				pxShip^.SetLevelClean(GetLevel());
+				pxShip^.SetIdleAnim();
+				pxShip^.ExamineEnemies(false);
+				Die();
 			endif;
-		endfor;
-		//
-		var ^CPirateShip pxShip=cast<CPirateShip>(CSrvWrap.GetObjMgr()^.CreateObj("ninigi_pirate_boss_ship",GetOwner(),vPos,vRot));
-		if(pxShip!=null)then
-			var ^CAttribs pxAttr=pxShip^.GetAttribs();
-			if(pxAttr!=null)then
-				pxAttr^.SetValue("clientpyramid_replacecard", GetName());
-			endif;
-			pxShip^.SetLevelClean(GetLevel());
-			pxShip^.SetIdleAnim();
-			pxShip^.ExamineEnemies(false);
-			Die();
 		endif;
 	endproc;
 	
@@ -12580,8 +12588,8 @@ class CSeasLaboratory inherit CRallyBuilding
 			m_bEquipped=true;
 			var CFourCC xLink="NOPE";
 			var ^CMirageDeco pxA;
-			m_avAddonOffsets.AddEntry({-3.4,-7.0,11.51}); // ParaworldFan: chimney_steam
-			m_avAddonOffsets.AddEntry({-9.2,-8.4,-0.4}); // ParaworldFan: crane pos
+			m_avAddonOffsets.AddEntry({-3.4,-7.0,11.51}); //chimney
+			m_avAddonOffsets.AddEntry({-9.2,-8.4,-0.4}); //crane
 			var int i, iC=m_avAddonOffsets.NumEntries();
 			for(i=0)cond(i<iC)iter(i++)do
 				pxA=cast<CMirageDeco>(CSrvWrap.GetObjMgr()^.CreateObj("seas_laboratory_misc_"+i.ToString(),GetOwner(),GetPos(),GetRotation()));

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/init/ui_select_building.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/init/ui_select_building.txt
@@ -641,6 +641,13 @@ Root {
 			volume 	= '75'
 		}
 	}
+	ninigi_launchpad_pirate_boss_selected {
+		global = '1'
+		sound_1 {
+			wav 	= 'ui_hu_palisade.wav'
+			volume 	= '75'
+		}
+	}
 	ui_ninigi_launchpad_zeppelin_selected {
 		global = '1'
 		sound_1 {

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/settings/Resources.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/settings/Resources.txt
@@ -608,6 +608,9 @@ Root {
 		ninigi_hunting_lodge_wreck {
 			value = '25'
 		}
+		ninigi_launchpad_pirate_boss {
+			value = '1000'
+		}
 		ninigi_minefield_wreck {
 			value = '100'
 		}

--- a/GameFiles/Basic/Data/MIRAGE/Texts/Help/H_Ninigi_Gebaeude.SEML
+++ b/GameFiles/Basic/Data/MIRAGE/Texts/Help/H_Ninigi_Gebaeude.SEML
@@ -362,6 +362,21 @@ There are also a few more special \{ref H_general.seml#_units} units\{/ref} whic
    \{/tooltiplong}
 \{/helpitem}
 
+\{helpitem -name _ninigi_launchpad_pirate_boss Repair dock}
+\{img /bunit:ninigi_pirate_boss_ship -ralign}
+   \{tooltipshort}
+%/class:bldg%
+   \{/tooltipshort}
+   \{tooltipmedium}
+• Constructs The Main Pirate ship
+   \{/tooltipmedium}
+   \{tooltiplong}
+Previously belonging to the Pirates, once have been a terror in the oceans, \{ref H_special_location.seml#_pirate_boss_row}the great ship \{/ref} was destroyed by \{ref H_general.seml#_heros}trio of the heroes \{/ref} and its wrecks have sanked near the Pirate village. \\{br}
+After the Pirates defeat, the ship wreckage was found and docked to shore by almighty \{ref H_story.seml#_story_ninigi}Dragon Clan tribe\{/ref}.
+They have built a dry dock and had reconstructed the sea giant for using in their own goals.
+   \{/tooltiplong}
+\{/helpitem}
+
 \{chapter -name _defense_buildings Defensive buildings}
 \{helpitem -name _ninigi_spike_trap Spike trap}
 \{img /bunit:ninigi_spike_trap -ralign}


### PR DESCRIPTION
* Build sequence of Norsemen StoneGuardiang is improved
* Norsemen stone guardian has destruction stages from now on
* Added new description for building which constrcuts the pirate ship
* AI now able to construct it as building from now on
* Added sound missing selection sound for this building
* Added missing building wreck
* Fixed seas poison ammo for specila_mobile_suit if its researched with FreeSpecials enabled
* Fixed scalps and Hitpoints values for ninigi_launchpad_pirate_boss