### PR TITLE
GfxPrefix fixes

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -25,6 +25,8 @@ General:
 - Fixed missing tooltips in some languages
 - Fixed missing translation in some languages
 - Fixed syntax errors in russain language tooltips
+- Fixed Pirates flag not being added to some preplaced||spawned pirate units
+- Fixed amazon warrior enemy selection voicelines
 - Various fixes in the options menu
 - Wild animals will play selection sounds when selected
 - Neutral buildings and resources will play selection sounds when selected

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/UISndMgr.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/UISndMgr.usl
@@ -265,7 +265,8 @@ class CUISoundMgr
 					switch( iSelectedObjectType )
 						case (1) do
 							var string sClass;
-							var string sGfxPrefix = (CGameWrap.GetClient().GetLevelInfo().GetGenericData())["PlayerSettings/Player_"+iOwnOwner.ToString()+"/Restrictions/Base"].GetValueS("GfxPrefix","");
+							var int iOwner = xSoundObj.GetObj()^.GetOwner();
+							var string sGfxPrefix = (CGameWrap.GetClient().GetLevelInfo().GetGenericData())["PlayerSettings/Player_"+iOwner.ToString()+"/Restrictions/Base/GfxPrefix"].Value();
 							CMirageClnMgr.ValidateName(sClass, xSoundObj);
 							//var string sClass = xSoundObj.GetObj()^.GetClassName();
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -5228,6 +5228,13 @@ class CFightingObj inherit CGameObj
 	endproc;
 	
 	///////
+	//	GetGfxPrefix()
+	///////
+	export proc string GetGfxPrefix()
+		return CSrvWrap.GetCurLevel()^.GetPlayer(GetOwner())^.GetGfxPrefix();
+	endproc;
+	
+	///////
 	//	GetBestWeapon()
 	///////
 	export proc void GetBestWeapon()

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/TransportObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/TransportObj.usl
@@ -299,6 +299,15 @@ class CTransportObj inherit CFightingObj
 		//AnimAction("");
 	endproc;
 	
+	export proc void AddGfxPrefixFlag()
+		var string sGfxPrefix=GetGfxPrefix();
+		var CFourCC xFlag="flag";
+		if(HasLink(xFlag) && (sGfxPrefix=="pirates"))then
+			if(HasLinkGFX())then RemLinkGFX(xFlag); endif;
+			SetLinkGFX(xFlag,"ninigi_pirateflag");
+		endif;
+	endproc;
+	
 	export proc void LinkToStock(string p_sGFX)
 		m_bLinkOccupied=true;
 		//??LinkGfx("");
@@ -429,6 +438,7 @@ class CTransportObj inherit CFightingObj
 	
 	export proc void OnPostLoad()
 		super.OnPostLoad();
+		AddGfxPrefixFlag();
 		LinkCaptainObj();
 		if(HasBuildUp())then
 			GetBuildUp()^.OnPostLoad();
@@ -1408,8 +1418,9 @@ class CTransportObj inherit CFightingObj
 			m_xCaptain=CObjHndl.Invalid();
 		endif;
 		SetTransportClass(0);
+		var string sGfxPrefix=GetGfxPrefix();
 		var CFourCC xFlag="flag";
-		if(HasLink(xFlag))then
+		if(HasLink(xFlag) && sGfxPrefix!="pirates")then
 			RemLinkGFX(xFlag);
 		endif;
 	endproc;
@@ -1633,25 +1644,36 @@ class CTransportObj inherit CFightingObj
 		if(m_sCurFlagDesc==sFlagDesc)then return; endif;
 		if(!CSrvWrap.GetGfxMgrBase().FindGraphicSetEntry(sFlagGFX))then return; endif;
 		m_sCurFlagDesc=sFlagDesc;
+		var string sGfxPrefix=GetGfxPrefix();
 		var CFourCC xFlag="flag";
 		if(HasBuildUp())then
 			var ^CGameObj pxLinkedObj=GetBuildUp()^.GetPrimaryLinkedObj().GetObj();
-			if(pxLinkedObj!=null && pxLinkedObj^.HasLink(xFlag))then
-				if(HasLink(xFlag))then RemLinkGFX(xFlag); endif;
+			if(pxLinkedObj!=null && pxLinkedObj^.HasLink(xFlag) && sGfxPrefix!="pirates")then
+				if(HasLink(xFlag) && sGfxPrefix!="pirates")then RemLinkGFX(xFlag); endif;
 				pxLinkedObj^.SetLinkGFX(xFlag,sFlagGFX);
+				return;
+			elseif(pxLinkedObj!=null && pxLinkedObj^.HasLink(xFlag) && sGfxPrefix=="pirates")then
+				if(HasLink(xFlag) && sGfxPrefix=="pirates")then RemLinkGFX(xFlag); endif;
+				pxLinkedObj^.SetLinkGFX(xFlag,"ninigi_pirateflag");
 				return;
 			endif;
 			if(HasAdditionalBuildUp(0))then
 				var ^CGameObj pxObj=GetAdditionalBuildUp(0)^.GetPrimaryLinkedObj().GetObj();
-				if(pxObj!=null && pxObj^.HasLink(xFlag))then
-					if(HasLink(xFlag))then RemLinkGFX(xFlag); endif;
+				if(pxObj!=null && pxObj^.HasLink(xFlag) && sGfxPrefix!="pirates")then
+					if(HasLink(xFlag) && sGfxPrefix!="pirates")then RemLinkGFX(xFlag); endif;
 					pxObj^.SetLinkGFX(xFlag,sFlagGFX);
+					return;
+				elseif(pxObj!=null && pxObj^.HasLink(xFlag) && sGfxPrefix=="pirates")then
+					if(HasLink(xFlag) && sGfxPrefix=="pirates")then RemLinkGFX(xFlag); endif;
+					pxObj^.SetLinkGFX(xFlag,"ninigi_pirateflag");
 					return;
 				endif;
 			endif;
 		endif;
-		if(HasLink(xFlag))then
+		if(HasLink(xFlag) && sGfxPrefix!="pirates")then
 			SetLinkGFX(xFlag,sFlagGFX);
+		elseif(HasLink(xFlag) && sGfxPrefix=="pirates")then
+			SetLinkGFX(xFlag,"ninigi_pirateflag");
 		endif;
 	endproc;
 	


### PR DESCRIPTION
* Fixed amazon warrior selection sounds were displaying incorrectly if the hostile or friendly unit was selected
* Fixed pirates flag not being added to some animals, vehicles and ships which were preplaced, spawned by a trigger or rpoduced in building. TODO: find out, why produced in harbour "ninigi_fishing_boat" doesnt get pirate flag addeed, but of same type preplaced unit or spawned through trigger has the pirate flag. Also if the unit will be leveled up, the flag also will appear.