### PR TITLE
GfxPrefix fixes Ver_2

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -25,7 +25,7 @@ General:
 - Fixed missing tooltips in some languages
 - Fixed missing translation in some languages
 - Fixed syntax errors in russain language tooltips
-- Fixed Pirates flag not being added to some preplaced||spawned pirate units
+- Fixed Pirates flag not being added to some preplaced or spawned pirate units
 - Fixed amazon warrior enemy selection voicelines
 - Various fixes in the options menu
 - Wild animals will play selection sounds when selected
@@ -45,7 +45,8 @@ Campaign maps:
 - Amazon warrior have female voiceover instead of male one from now on
 - Fixed floating buildings, units and incorrect camera's angles on mission 13 in three cutscenes
 - Classic pirate ship from now on plays destruction animation of decks, once the unit being deleted. Ship decks and cannons no longer stuck in the air. Animation based on the amount, how many decks the ship had, when got order for Deletion.
-- Classis pirate ship no longer can do any actions, once all its decks being destroyed.
+- Classic pirate ship no longer can do any actions, once all its decks being destroyed.
+- Captain Miyagi from now has Pirate flag as well when fighting for pirates.
 
 Heroes:
 - Larry, Barry and Harry are affected by Dustriders Town Center Resource tool upgrades 1,2,3 and 4

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -5231,7 +5231,8 @@ class CFightingObj inherit CGameObj
 	//	GetGfxPrefix()
 	///////
 	export proc string GetGfxPrefix()
-		return CSrvWrap.GetCurLevel()^.GetPlayer(GetOwner())^.GetGfxPrefix();
+		if(CBasePlayer.GetPlayer(GetOwner())==null)then return ""; endif;
+		return CBasePlayer.GetPlayer(GetOwner())^.GetGfxPrefix();
 	endproc;
 	
 	///////

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/TransportObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/TransportObj.usl
@@ -299,12 +299,16 @@ class CTransportObj inherit CFightingObj
 		//AnimAction("");
 	endproc;
 	
-	export proc void AddGfxPrefixFlag()
-		var string sGfxPrefix=GetGfxPrefix();
+	export proc bool AddGfxPrefixFlag()
+		if(GetPlayerTribeName().IsEmpty() || GetPlayerTribeName()!="Ninigi" || GetGfxPrefix()!="pirates")then return false; endif;
 		var CFourCC xFlag="flag";
-		if(HasLink(xFlag) && (sGfxPrefix=="pirates"))then
+		if(GetClassName()=="ninigi_parasaurolophus_drums")then
+			return true;
+		elseif(HasLink(xFlag))then
 			if(HasLinkGFX())then RemLinkGFX(xFlag); endif;
-			SetLinkGFX(xFlag,"ninigi_pirateflag");
+			return SetLinkGFX(xFlag,"ninigi_pirateflag");
+		else
+			return false;
 		endif;
 	endproc;
 	
@@ -424,6 +428,9 @@ class CTransportObj inherit CFightingObj
 	
 	export proc void OnInit(bool p_bLoad)
 		super.OnInit(p_bLoad);
+		if(!CMirageSrvMgr.SDK())then
+			AddGfxPrefixFlag();
+		endif;
 		RegisterFlockingBoid();
 		if(!p_bLoad)then
 			SetTransportClass(0);
@@ -438,7 +445,6 @@ class CTransportObj inherit CFightingObj
 	
 	export proc void OnPostLoad()
 		super.OnPostLoad();
-		AddGfxPrefixFlag();
 		LinkCaptainObj();
 		if(HasBuildUp())then
 			GetBuildUp()^.OnPostLoad();
@@ -1418,9 +1424,8 @@ class CTransportObj inherit CFightingObj
 			m_xCaptain=CObjHndl.Invalid();
 		endif;
 		SetTransportClass(0);
-		var string sGfxPrefix=GetGfxPrefix();
 		var CFourCC xFlag="flag";
-		if(HasLink(xFlag) && sGfxPrefix!="pirates")then
+		if(HasLink(xFlag) && (GetGfxPrefix()!="pirates"))then
 			RemLinkGFX(xFlag);
 		endif;
 	endproc;
@@ -1638,43 +1643,39 @@ class CTransportObj inherit CFightingObj
 	export proc void CheckLevelFlag()
 		var int iLevel=GetLevel();
 		var string sTribe=GetPlayerTribeName();
+		var string sGfxPrefix=GetGfxPrefix();
 		var string sFlagGFX=sTribe+"_animal_flag_0"+(iLevel+1).ToString();
 		var string sFlagDesc=sFlagGFX+"_"+m_iBuildUpType.ToString();
 		//redundancy check
 		if(m_sCurFlagDesc==sFlagDesc)then return; endif;
 		if(!CSrvWrap.GetGfxMgrBase().FindGraphicSetEntry(sFlagGFX))then return; endif;
 		m_sCurFlagDesc=sFlagDesc;
-		var string sGfxPrefix=GetGfxPrefix();
 		var CFourCC xFlag="flag";
 		if(HasBuildUp())then
 			var ^CGameObj pxLinkedObj=GetBuildUp()^.GetPrimaryLinkedObj().GetObj();
-			if(pxLinkedObj!=null && pxLinkedObj^.HasLink(xFlag) && sGfxPrefix!="pirates")then
-				if(HasLink(xFlag) && sGfxPrefix!="pirates")then RemLinkGFX(xFlag); endif;
-				pxLinkedObj^.SetLinkGFX(xFlag,sFlagGFX);
-				return;
-			elseif(pxLinkedObj!=null && pxLinkedObj^.HasLink(xFlag) && sGfxPrefix=="pirates")then
-				if(HasLink(xFlag) && sGfxPrefix=="pirates")then RemLinkGFX(xFlag); endif;
-				pxLinkedObj^.SetLinkGFX(xFlag,"ninigi_pirateflag");
+			if(pxLinkedObj!=null && pxLinkedObj^.HasLink(xFlag))then
+				if(HasLink(xFlag))then RemLinkGFX(xFlag); endif;
+				if(sTribe=="Ninigi" && sGfxPrefix=="pirates")then
+					pxLinkedObj^.SetLinkGFX(xFlag,"ninigi_pirateflag");
+				else
+					pxLinkedObj^.SetLinkGFX(xFlag,sFlagGFX);
+				endif;
 				return;
 			endif;
 			if(HasAdditionalBuildUp(0))then
 				var ^CGameObj pxObj=GetAdditionalBuildUp(0)^.GetPrimaryLinkedObj().GetObj();
-				if(pxObj!=null && pxObj^.HasLink(xFlag) && sGfxPrefix!="pirates")then
-					if(HasLink(xFlag) && sGfxPrefix!="pirates")then RemLinkGFX(xFlag); endif;
-					pxObj^.SetLinkGFX(xFlag,sFlagGFX);
-					return;
-				elseif(pxObj!=null && pxObj^.HasLink(xFlag) && sGfxPrefix=="pirates")then
-					if(HasLink(xFlag) && sGfxPrefix=="pirates")then RemLinkGFX(xFlag); endif;
-					pxObj^.SetLinkGFX(xFlag,"ninigi_pirateflag");
+				if(pxObj!=null && pxObj^.HasLink(xFlag))then
+					if(HasLink(xFlag))then RemLinkGFX(xFlag); endif;
+					if(sTribe=="Ninigi" && sGfxPrefix=="pirates")then
+						pxObj^.SetLinkGFX(xFlag,"ninigi_pirateflag");
+					else
+						pxObj^.SetLinkGFX(xFlag,sFlagGFX);
+					endif;
 					return;
 				endif;
 			endif;
 		endif;
-		if(HasLink(xFlag) && sGfxPrefix!="pirates")then
-			SetLinkGFX(xFlag,sFlagGFX);
-		elseif(HasLink(xFlag) && sGfxPrefix=="pirates")then
-			SetLinkGFX(xFlag,"ninigi_pirateflag");
-		endif;
+		if(!AddGfxPrefixFlag())then if(HasLink(xFlag))then SetLinkGFX(xFlag,sFlagGFX); endif; endif;
 	endproc;
 	
 	///////


### PR DESCRIPTION
* "ninigi_fishing_boat" from now on always has pirate flag if "pirates" GfxPrefix enabled
* "ninigi_parasaurolophus_drums" from on dont have pirate flag, because it looks odd in its position on animal model
* Captain Miyagi if "pirates" GfxPrefix enabled will have pirate flag as well on his baryonyx
TODO:
"Parasaurolophus" model has "flag" link too far away from saddle to use it on "ninigi_parasaurolophus_drums". I suggest using "Ninigi_drumwagon" instead for pirate flag linking, but its lack this link at all.
Enlisted models below doesnt have link "flag", so adding pirate or common levelflag is impossible
"Saltasaurus"
"Ninigi_drumwagon"
"ninigi_cargolifter"
"ninigi_dirigible"
"gigantopithecus"
"FlyingTrader"
"seax_helicopter"