### PR TITLE
Animal flags fixes

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -19,6 +19,8 @@ General:
 - Pirate ship chain on skirmish maps and in mission 6 are playing "Open" & "Close" animation from now on
 - Fixed bug with Holy City gates destruction animation wasnt playing
 - Campaing avatar on mission "Single B42: Cold Day in Hell" has a corpse damage, corpse resources and death animation from now on
+- Fixed missing animal flags for preplaced SDK units/spawned through trigger
+- Fixed incorrect animal flags for animals/vehicles/ships if the starting tribe not matching the unit tribe
 - Fixed missing stances icons
 - Fixed non working corpse resources values for campaign valhalla stone statues and campaign avatar
 - Fixed incorrect heroes tooltips in all languages

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/TransportObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/TransportObj.usl
@@ -299,19 +299,6 @@ class CTransportObj inherit CFightingObj
 		//AnimAction("");
 	endproc;
 	
-	export proc bool AddGfxPrefixFlag()
-		if(GetPlayerTribeName().IsEmpty() || GetPlayerTribeName()!="Ninigi" || GetGfxPrefix()!="pirates")then return false; endif;
-		var CFourCC xFlag="flag";
-		if(GetClassName()=="ninigi_parasaurolophus_drums")then
-			return true;
-		elseif(HasLink(xFlag))then
-			if(HasLinkGFX())then RemLinkGFX(xFlag); endif;
-			return SetLinkGFX(xFlag,"ninigi_pirateflag");
-		else
-			return false;
-		endif;
-	endproc;
-	
 	export proc void LinkToStock(string p_sGFX)
 		m_bLinkOccupied=true;
 		//??LinkGfx("");
@@ -428,8 +415,9 @@ class CTransportObj inherit CFightingObj
 	
 	export proc void OnInit(bool p_bLoad)
 		super.OnInit(p_bLoad);
+//		if(!CMirageSrvMgr.SDK() && m_sCurFlagDesc.IsEmpty())then	// might need extra checkup, if after loading up savefile pirate flags will get replaced to common animal flags by CheckLevelFlag()
 		if(!CMirageSrvMgr.SDK())then
-			AddGfxPrefixFlag();
+			CheckLevelFlag();
 		endif;
 		RegisterFlockingBoid();
 		if(!p_bLoad)then
@@ -1641,9 +1629,9 @@ class CTransportObj inherit CFightingObj
 	endproc;
 	
 	export proc void CheckLevelFlag()
+		if(GetClassName()=="ninigi_parasaurolophus_drums")then return; endif;
 		var int iLevel=GetLevel();
-		var string sTribe=GetPlayerTribeName();
-		var string sGfxPrefix=GetGfxPrefix();
+		var string sTribe=GetTribeName();
 		var string sFlagGFX=sTribe+"_animal_flag_0"+(iLevel+1).ToString();
 		var string sFlagDesc=sFlagGFX+"_"+m_iBuildUpType.ToString();
 		//redundancy check
@@ -1655,27 +1643,21 @@ class CTransportObj inherit CFightingObj
 			var ^CGameObj pxLinkedObj=GetBuildUp()^.GetPrimaryLinkedObj().GetObj();
 			if(pxLinkedObj!=null && pxLinkedObj^.HasLink(xFlag))then
 				if(HasLink(xFlag))then RemLinkGFX(xFlag); endif;
-				if(sTribe=="Ninigi" && sGfxPrefix=="pirates")then
-					pxLinkedObj^.SetLinkGFX(xFlag,"ninigi_pirateflag");
-				else
-					pxLinkedObj^.SetLinkGFX(xFlag,sFlagGFX);
-				endif;
+				pxLinkedObj^.SetLinkGFX(xFlag,sFlagGFX);
 				return;
 			endif;
 			if(HasAdditionalBuildUp(0))then
 				var ^CGameObj pxObj=GetAdditionalBuildUp(0)^.GetPrimaryLinkedObj().GetObj();
 				if(pxObj!=null && pxObj^.HasLink(xFlag))then
 					if(HasLink(xFlag))then RemLinkGFX(xFlag); endif;
-					if(sTribe=="Ninigi" && sGfxPrefix=="pirates")then
-						pxObj^.SetLinkGFX(xFlag,"ninigi_pirateflag");
-					else
-						pxObj^.SetLinkGFX(xFlag,sFlagGFX);
-					endif;
+					pxObj^.SetLinkGFX(xFlag,sFlagGFX);
 					return;
 				endif;
 			endif;
 		endif;
-		if(!AddGfxPrefixFlag())then if(HasLink(xFlag))then SetLinkGFX(xFlag,sFlagGFX); endif; endif;
+		if(HasLink(xFlag))then
+			SetLinkGFX(xFlag,sFlagGFX);
+		endif;
 	endproc;
 	
 	///////

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
@@ -283,7 +283,17 @@ class CSBaryonyx inherit CAnimal
 	endproc;
 	
 	export proc void CheckLevelFlag()
-		return;
+		var string sTribe=GetPlayerTribeName();
+		var string sGfxPrefix=GetGfxPrefix();
+		if(sTribe!="Ninigi" || sGfxPrefix!="pirates")then return; endif;
+		var int iLevel=GetLevel();
+		var string sFlagGFX=sTribe+"_animal_flag_0"+(iLevel+1).ToString();
+		var string sFlagDesc=sFlagGFX+"_"+m_iBuildUpType.ToString();
+		if(m_sCurFlagDesc==sFlagDesc)then return; endif;
+		if(!CSrvWrap.GetGfxMgrBase().FindGraphicSetEntry(sFlagGFX))then return; endif;
+		m_sCurFlagDesc=sFlagDesc;
+		var CFourCC xFlag="flag";
+		if(HasLink(xFlag))then SetLinkGFX(xFlag,sFlagGFX); endif;
 	endproc;
 	
 	export proc void OnTechTreeChange(ref CStringArray p_rasChanges)


### PR DESCRIPTION
* Fixed multitribe level flag visual bug for ANML/VHCL/SHIP unit types (view screen below)
* Optimized the code for the Pirate Flagswhich added with "pirates" GfxPrefix is on
![scr_20240910_201401](https://github.com/user-attachments/assets/37097e07-b194-4724-ace7-09b1a6411da8)