### PR TITLE
Pirates GfxPrefix Flag Save Fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/TransportObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/TransportObj/TransportObj.usl
@@ -415,9 +415,8 @@ class CTransportObj inherit CFightingObj
 	
 	export proc void OnInit(bool p_bLoad)
 		super.OnInit(p_bLoad);
-//		if(!CMirageSrvMgr.SDK() && m_sCurFlagDesc.IsEmpty())then	// might need extra checkup, if after loading up savefile pirate flags will get replaced to common animal flags by CheckLevelFlag()
 		if(!CMirageSrvMgr.SDK())then
-			CheckLevelFlag();
+			ResetFlag();
 		endif;
 		RegisterFlockingBoid();
 		if(!p_bLoad)then
@@ -1633,6 +1632,7 @@ class CTransportObj inherit CFightingObj
 		var int iLevel=GetLevel();
 		var string sTribe=GetTribeName();
 		var string sFlagGFX=sTribe+"_animal_flag_0"+(iLevel+1).ToString();
+		if(sTribe=="Ninigi" && GetGfxPrefix()=="pirates")then sFlagGFX="ninigi_pirateflag"; endif;
 		var string sFlagDesc=sFlagGFX+"_"+m_iBuildUpType.ToString();
 		//redundancy check
 		if(m_sCurFlagDesc==sFlagDesc)then return; endif;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/mirage/Mirage.usl
@@ -284,8 +284,7 @@ class CSBaryonyx inherit CAnimal
 	
 	export proc void CheckLevelFlag()
 		var string sTribe=GetPlayerTribeName();
-		var string sGfxPrefix=GetGfxPrefix();
-		if(sTribe!="Ninigi" || sGfxPrefix!="pirates")then return; endif;
+		if(sTribe!="Ninigi" || GetGfxPrefix()!="pirates")then return; endif;
 		var int iLevel=GetLevel();
 		var string sFlagGFX=sTribe+"_animal_flag_0"+(iLevel+1).ToString();
 		var string sFlagDesc=sFlagGFX+"_"+m_iBuildUpType.ToString();


### PR DESCRIPTION
Because of multiple calls of ResetFlag(0 function by CTransportObj logic, after loading up Save it removes Linked flag, but the source code of GfxPrefix logic is not working well after that and not adding flag back to already existing objects on map. To prevent that, the flag addding enforced through level CheckLevelFlag() function like it was done in previous Commits, in order to fix the issue in all cases.