### PR TITLE
New Default Stance for ninigi_drums when they get weapon

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/animals/Animal.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/animals/Animal.usl
@@ -4952,6 +4952,7 @@ class CParasaurolophus inherit CAnimal
 				m_xExtraCaptain=pxC^.GetHandle();
 				GetBuildUp()^.AddObj(m_xExtraCaptain, "Ride");
 				pxC^.SetAnim("ride_idle_0",3);
+				SetAggressionState(0);
 				SetCanFightAttrib(true);
 			elseif(GetRndInvMaskSingleFlagInv(VIS_FLAG_ANML_SADDLE) && !bInvention)then
 				SetRndInvMaskSingleFlagInv(VIS_FLAG_ANML_SADDLE,false);


### PR DESCRIPTION
* Ninigi war drums from now on have default stance "stand ground" (attacks unit only if his attack range alllows to attack the enemy without moving from his spot) once the weapon upgrades has been researched. This will allow better control of war drums so when used in big army they wont rush forward automatically on enemies, but if somebody attack them they fight back but dont move from their spot, until player orders to attack some unit or changes their state.
TODO List in Discord: #69