### PR TITLE
snipers can now randomly high roll and crit enemies

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -60,6 +60,7 @@ Heroes:
 - Bela composite bow range per level changed from 40/42/44/46/50 to 50/50/50/50/50
 - Ada Loven musket range per level changed from 35/35/35/35/35 to 45/45/45/45/45
 - Ada Loven from now on has a poison upgrade (Kleeman tier 4) for ranged attack, poison damage is 5/7/10/15/20 per 10/11/12/14/15 ticks
+- Ada Loven will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 penalty when on transport)   
 - Babbage lvl 5 now correctly no longer gives global +50% buildup speed, instead giving +20 melee and ranged defense to all infantry
 - Taslow lvl 5 now correctly grants +33% buildup speed globally
 
@@ -109,6 +110,7 @@ SEAS:
 - Added SEAS laboratory work animation, that plays when building produces unit or research upgrade
 - Restored SEAS laboratory crane, that was deleted long time ago
 - Rocketman was constantly spamming the shot effect -> this has been fixed
+- Sniper will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 penalty when on transport)  
 
 AI:
 - Fixed bug, where AI were able to delete pirate ship decks separately from the main unit one by one. Now, no longer.

--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -60,7 +60,7 @@ Heroes:
 - Bela composite bow range per level changed from 40/42/44/46/50 to 50/50/50/50/50
 - Ada Loven musket range per level changed from 35/35/35/35/35 to 45/45/45/45/45
 - Ada Loven from now on has a poison upgrade (Kleeman tier 4) for ranged attack, poison damage is 5/7/10/15/20 per 10/11/12/14/15 ticks
-- Ada Loven will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 penalty when on transport)   
+- Ada Loven will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 level penalty when on transport) dealing +20%/+600%/100%/+40% vs Hero/Infantry/Animal/Vehichle
 - Babbage lvl 5 now correctly no longer gives global +50% buildup speed, instead giving +20 melee and ranged defense to all infantry
 - Taslow lvl 5 now correctly grants +33% buildup speed globally
 
@@ -110,7 +110,7 @@ SEAS:
 - Added SEAS laboratory work animation, that plays when building produces unit or research upgrade
 - Restored SEAS laboratory crane, that was deleted long time ago
 - Rocketman was constantly spamming the shot effect -> this has been fixed
-- Sniper will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 penalty when on transport)  
+- Sniper will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 penalty when on transport) dealing -50%/+400%/100%/+0%(bypasses -60% from TT) vs Hero/Infantry/Animal/Vehichle
 
 AI:
 - Fixed bug, where AI were able to delete pirate ship decks separately from the main unit one by one. Now, no longer.

--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -110,7 +110,7 @@ SEAS:
 - Added SEAS laboratory work animation, that plays when building produces unit or research upgrade
 - Restored SEAS laboratory crane, that was deleted long time ago
 - Rocketman was constantly spamming the shot effect -> this has been fixed
-- Sniper will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 penalty when on transport) dealing -50%/+400%/+100%/+0%(bypasses -60% from TT) vs Hero/Infantry/Animal/Vehichle
+- Sniper will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 level penalty when on transport) dealing -50%/+400%/+100%/+0%(bypasses -60% from TT) vs Hero/Infantry/Animal/Vehichle
 
 AI:
 - Fixed bug, where AI were able to delete pirate ship decks separately from the main unit one by one. Now, no longer.

--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -60,7 +60,7 @@ Heroes:
 - Bela composite bow range per level changed from 40/42/44/46/50 to 50/50/50/50/50
 - Ada Loven musket range per level changed from 35/35/35/35/35 to 45/45/45/45/45
 - Ada Loven from now on has a poison upgrade (Kleeman tier 4) for ranged attack, poison damage is 5/7/10/15/20 per 10/11/12/14/15 ticks
-- Ada Loven will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 level penalty when on transport) dealing +20%/+600%/100%/+40% vs Hero/Infantry/Animal/Vehichle
+- Ada Loven will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 level penalty when on transport) dealing +20%/+600%/+100%/+40% vs Hero/Infantry/Animal/Vehichle
 - Babbage lvl 5 now correctly no longer gives global +50% buildup speed, instead giving +20 melee and ranged defense to all infantry
 - Taslow lvl 5 now correctly grants +33% buildup speed globally
 
@@ -110,7 +110,7 @@ SEAS:
 - Added SEAS laboratory work animation, that plays when building produces unit or research upgrade
 - Restored SEAS laboratory crane, that was deleted long time ago
 - Rocketman was constantly spamming the shot effect -> this has been fixed
-- Sniper will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 penalty when on transport) dealing -50%/+400%/100%/+0%(bypasses -60% from TT) vs Hero/Infantry/Animal/Vehichle
+- Sniper will now randomly perform a sniper "high roll" critical shot with 3%/6%/11%/20%/33%/50% chance per level (-1 penalty when on transport) dealing -50%/+400%/+100%/+0%(bypasses -60% from TT) vs Hero/Infantry/Animal/Vehichle
 
 AI:
 - Fixed bug, where AI were able to delete pirate ship decks separately from the main unit one by one. Now, no longer.

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -5875,6 +5875,18 @@ class CFightingObj inherit CGameObj
 			endif;
 		endif;
 		fDamage*=p_fFactor;
+		//Kr1s1m: Take modified damage randomly if attacked by a projectile fired from a SEAS Sniper
+		if(p_bProjectile && (p_pxEnemy^.GetClassName()=="seas_sniper" || p_pxEnemy^.GetClassName()=="lovelace_s0"))then
+			var ^CCharacter pxSniper = cast<CCharacter>(p_pxEnemy);
+			if(pxSniper!=null)then
+				fDamage*=pxSniper^.GetRandomSniperBoniFactor(this);
+				var string sDamage = fDamage.ToInt().ToString();
+				//KLog.LogSpam("Kr1s1m-ALERT-2","CFightingObj::TakeDmg "+GetClassName()+" taking "+sDamage+" damage from sniper, pxSniper!=null");
+			else
+				//KLog.LogSpam("Kr1s1m-ALERT-2", "CFightingObj::TakeDmg <!ERROR!>: "+GetClassName()+" taking 0 damage from sniper, pxSniper==null");
+				return 0.0;//Kr1s1m: Something went wrong - the CFightingObj was not cast into a sniper CCharacter
+			endif;
+		endif;
 		//Henry: Tarna and aje liopleurodon gets freezing ability too
 		if(p_pxEnemy^.GetClassName()=="ninigi_icespearman"||p_pxEnemy^.GetClassName()=="Tarna_s0"/*||p_pxEnemy^.GetClassName()=="aje_liopleurodon"*/)then
 			SetIced(p_pxEnemy^.GetGlacialEpoch(),p_pxEnemy^.GetIceMelting());
@@ -7896,7 +7908,7 @@ class CFightingObj inherit CGameObj
 		var CObjList xL;
 		xQuery.Execute(xL);
 		p_fAngle*=0.5;
-		p_fAngle=Math2.DegToRad(p_fAngle);
+		p_fAngle=(Math.Pi()/180.0)*p_fAngle;
 		p_fRadius+=GetCollisionRadius()+2.0f;
 		var vec3 vDir=(p_vTarget - vPos);
 		var int i, iC=xL.NumEntries();
@@ -11795,7 +11807,7 @@ class CFightingObj inherit CGameObj
 	
 	export proc void SetIced(real p_fDuration,real p_fResistStart)
 		if(m_bSlaveInvincible)then return; endif;
-		if(GetType()=="NEST")then return; endif;
+		if(GetType()=="NEST"||GetType()=="BLDG")then return; endif;
 		if(IsIceImmun())then return; endif;
 		var real fImmunityTime=GetImmunityTime();
 		if(HasTimer(TIMER_FROST))then
@@ -16136,7 +16148,7 @@ class CFightingObj inherit CGameObj
 		xQuery.Execute(xL);
 		xL.Include(p_xPT);
 		p_fAngle*=0.5;
-		p_fAngle=Math2.DegToRad(p_fAngle);
+		p_fAngle=(Math.Pi()/180.0)*p_fAngle;
 		p_fRadius+=GetCollisionRadius()+2.0f;
 		var vec3 vDir=(p_vTarget - vPos);
 		var int i, iC=xL.NumEntries();

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -7908,7 +7908,7 @@ class CFightingObj inherit CGameObj
 		var CObjList xL;
 		xQuery.Execute(xL);
 		p_fAngle*=0.5;
-		p_fAngle=(Math.Pi()/180.0)*p_fAngle;
+		p_fAngle=Math2.DegToRad(p_fAngle);
 		p_fRadius+=GetCollisionRadius()+2.0f;
 		var vec3 vDir=(p_vTarget - vPos);
 		var int i, iC=xL.NumEntries();
@@ -11807,7 +11807,7 @@ class CFightingObj inherit CGameObj
 	
 	export proc void SetIced(real p_fDuration,real p_fResistStart)
 		if(m_bSlaveInvincible)then return; endif;
-		if(GetType()=="NEST"||GetType()=="BLDG")then return; endif;
+		if(GetType()=="NEST")then return; endif;
 		if(IsIceImmun())then return; endif;
 		var real fImmunityTime=GetImmunityTime();
 		if(HasTimer(TIMER_FROST))then
@@ -16148,7 +16148,7 @@ class CFightingObj inherit CGameObj
 		xQuery.Execute(xL);
 		xL.Include(p_xPT);
 		p_fAngle*=0.5;
-		p_fAngle=(Math.Pi()/180.0)*p_fAngle;
+		p_fAngle=Math2.DegToRad(p_fAngle);
 		p_fRadius+=GetCollisionRadius()+2.0f;
 		var vec3 vDir=(p_vTarget - vPos);
 		var int i, iC=xL.NumEntries();

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/character.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/character/character.usl
@@ -3539,6 +3539,70 @@ class CCharacter inherit CFightingObj
 		return fAllOverFactor;
 	endproc;
 	
+	export proc real GetRandomSniperBoniFactor(^CFightingObj p_pxTarget)
+		var real fBoniFactor=1.0; //Kr1s1m: default bonus factor *1.0 -> unmodified damage
+		//Kr1s1m: If the user is not a valid , do not modify damage
+		if(GetClassName()!="seas_sniper" && GetClassName()!="lovelace_s0")then return fBoniFactor; endif;
+		var bool bLovelace=GetClassName()=="lovelace_s0";
+		var bool bCriticalEffect=false;
+		var CFourCC xType=p_pxTarget^.GetType();
+		var string sTribe=p_pxTarget^.GetTribeName();
+		var int iTransportPenalty=0;
+		if(GetTransportObj().IsValid())then iTransportPenalty=1; endif;
+		var int iLvl=(GetLevel() + 1)-iTransportPenalty;
+		var int iMax=Math.Pow(2.0, (5-iLvl).ToReal()).ToInt();
+		var int iRandom=Random.GetInt()%(iMax+1);
+		var bool bHighroll=iRandom==iMax;
+		//Kr1s1m: choose unformly at random a number in interval [0, iMax]
+		//Kr1s1m: iLvl 0 -> 2^(5-0) = 32 	-> [0, 32] 	-> 1/33 chance to pick exactly 32 	-> 3% chance to "highroll"
+		//Kr1s1m: iLvl 1 -> 2^(5-1) = 16 	-> [0, 16] 	-> 1/17 chance to pick exactly 16 	-> 6% chance to "highroll"
+		//Kr1s1m: iLvl 2 -> 2^(5-2) = 8 	-> [0, 8] 	-> 1/9 chance to pick exactly 8 	-> 11% chance to "highroll"
+		//Kr1s1m: iLvl 3 -> 2^(5-3) = 4 	-> [0, 4] 	-> 1/5 chance to pick exactly 4 	-> 20% chance to "highroll"
+		//Kr1s1m: iLvl 4 -> 2^(5-4) = 2 	-> [0, 2] 	-> 1/3 chance to pick exactly 2 	-> 33% chance to "highroll"
+		//Kr1s1m: iLvl 5 -> 2^(5-5) = 1 	-> [0, 1] 	-> 1/2 chance to pick exactly 1 	-> 50% chance to "highroll"
+		if(bHighroll)then//Kr1s1m: If the sniper has "highrolled"...
+			bCriticalEffect=true;
+			if(bLovelace)then//Kr1s1m: ...and the sniper is Ada...
+				if(sTribe=="Special")then
+					fBoniFactor=1.2; //Kr1s1m:... +20% damage vs heroes... bounty
+				elseif(xType=="CHTR")then
+					fBoniFactor=7.0; //Kr1s1m:... +600% damage vs infantry... headshot
+				elseif(xType=="ANML")then
+					fBoniFactor=1.5; //Kr1s1m:... +50% damage vs animals... hunter (+110% total due to TT +40% ANML)
+				elseif(xType=="VHCL")then
+					fBoniFactor=1.4; //Kr1s1m:... +40% damage vs machines... hatch
+				else
+					bCriticalEffect=false;
+				endif;
+			else//Kr1s1m: Else it was SEAS Sniper...
+				if(sTribe=="Special")then
+					fBoniFactor=0.5; //Kr1s1m:... -50% damage vs heroes... plot armor
+				elseif(xType=="CHTR")then
+					fBoniFactor=5.0; //Kr1s1m:... +400% damage vs infantry... headshot
+				elseif(xType=="ANML")then
+					fBoniFactor=2.0; //Kr1s1m:... +100% damage vs animals... hunter
+				elseif(xType=="VHCL")then
+					fBoniFactor=2.6; //Kr1s1m:... +160% damage vs machines... hatch (+0% total due to TT -60% VHCL)
+				else
+					bCriticalEffect=false;
+				endif;
+			endif;
+			if(bCriticalEffect)then 
+				SetDemoteEffect(true,2.0f);//Kr1s1m: Set particle effect, to signal the highroll
+			endif;
+			
+		endif;
+		//var string sHighroll="";
+		//if(bHighroll && bCriticalEffect)then sHighroll+="(highroll)"; endif;
+		//if(bLovelace)then sHighroll+=" <Lovelace>"; endif;
+		//if(iTransportPenalty>0)then sHighroll+= " {transport}"; endif;
+		//var string sLogMsg="CCharacter::GetRandomSniperBoniFactor";
+		//sLogMsg+=" factor="+fBoniFactor.ToString()+", target_type="+xType.ToString()+"("+sTribe+"),";
+		//sLogMsg+=" rolled "+iRandom.ToString()+" from [0, "+iMax.ToString()+"] "+sHighroll;
+		//KLog.LogSpam("Kr1s1m-ALERT-2", sLogMsg);
+		return fBoniFactor;
+	endproc;
+	
 	export proc bool DiePerHeadOff(^CCharacter p_pxEnemy, ^CCharacterCorpse p_pxCorpse)
 		var array string asHeadOffAnims;
 		asHeadOffAnims.AddEntry("res_strike_13");


### PR DESCRIPTION
- SEAS Sniper and Ada Lovelace can now "high roll" and critically strike based on random chance
- SEAS Sniper and Ada Lovelace have separate critical damage modifiers (factors) for easier balance
- Red particles appear around projectile firing character after successfully damaging an enemy (TakeDmg)
- "High roll" chance is based on actual level and the level gets -1 penalty when the sniper is on transport
- Lvl 0 -> 3% chance to "highroll"
- Lvl 1 -> 6% chance to "highroll"
- Lvl 2 -> 11% chance to "highroll"
- Lvl 3 -> 20% chance to "highroll"
- Lvl 4 -> 33% chance to "highroll"
- Lvl 5 -> 50% chance to "highroll"
- (Heroes have plot armor) deals heavy damage and one shots weaker infantry (headshot), bypasses machine armor (hatch), doubles against animals (hunter)
- TODO: Tweak multipliers (if needed), fix TT crash rpg leftover "seas_sniper=100" further (if needed), replace the used downlevel particle effect with unique (if possible)