### PR TITLE
added exception paths for alien commands

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/Mirage_UI_scripts.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/Mirage_UI_scripts.usl
@@ -563,27 +563,36 @@ class CMirageServer inherit CWindow
 			//KLog.LogSpam("Kr1s1m", "CMirageServer::SetAndLockMirageSetting begin");
 			if(p_sValue=="")then return; endif;
 			var CConfig xConf;
-			var int iOldValue = xConf.GetSetI("Server/GameplayOptions/"+p_sSettingName, 0);
+			var string sPath = "Server/GameplayOptions/";
+			var string sControlName=p_sSettingName;
+			//Kr1s1m: Exceptions for AllowAlienCommands, since we can't put it inside GameplayOptions w/out editing the exe...
+			if(p_sSettingName=="AllowAlienCommands")then 
+				sControlName="AlienCommands"; //Kr1s1m: ...map AllowAlienCommands value to AlienCommands control name...
+				sPath="Server/";/*Kr1s1m: ...path hardcoded in exe*/
+			endif;
+			var int iOldValue = xConf.GetSetI(sPath+p_sSettingName, 0);
 			var int iValue = p_sValue.ToInt();
 			if(p_sSettingType=="CheckBox")then
-				var ^CCheckBox pxCheckBox = cast<CCheckBox>(GetControl(p_sSettingName));
+				var ^CCheckBox pxCheckBox = cast<CCheckBox>(GetControl(sControlName));
 				pxCheckBox^.SetChecked(iValue);
 				pxCheckBox^.SetDisabled(p_bLock);
 			elseif(p_sSettingType=="DropList")then
-				var ^CDropList pxDrop = cast<CDropList>(GetControl(p_sSettingName+"Droplist"));
+				sControlName+="Droplist";
+				var ^CDropList pxDrop = cast<CDropList>(GetControl(sControlName));
 				if(pxDrop^.NumItems()>iValue && pxDrop^.NumItems()>0)then
 					pxDrop^.Select(iValue);
 				endif;
 				pxDrop^.SetDisabled(p_bLock);
 			elseif(p_sSettingType=="SpinCtrlNumber")then
-				var ^CSpinCtrlNumber pxSpinCtrl = cast<CSpinCtrlNumber>(GetControl(p_sSettingName+"SpinCtrl"));
+				sControlName+="SpinCtrl";
+				var ^CSpinCtrlNumber pxSpinCtrl = cast<CSpinCtrlNumber>(GetControl(sControlName));
 				pxSpinCtrl^.SetValue(iValue);
 				pxSpinCtrl^.SetEditable(false);
 				pxSpinCtrl^.SetDisabled(p_bLock);
 			endif;
 			if(iValue!=iOldValue)then
-				xConf.SetI("Server/GameplayOptions/"+p_sSettingName, iValue);
-				CGameWrap.GetGame().SetAttrib(p_sSettingName,iValue);
+				xConf.SetI(sPath+p_sSettingName, iValue);
+				CGameWrap.GetGame().SetAttrib(p_sSettingName, iValue);
 				//KLog.LogSpam("Kr1s1m", "CGameWrap.GetGame().SetAttrib("+p_sSettingName+", "+p_sValue+")");
 			endif;
 			//var string sLocked = "";

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/MirageClnMgr.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/MirageClnMgr.usl
@@ -1037,7 +1037,10 @@ class CMirageClnMgr
 							var ^CPropDB.CNode pxSettingNode = ^(pxSettingTypeNode^.Get(j));
 							var string sSettingName = pxSettingNode^.Name();
 							var int iValue = pxSettingNode^.ValueI();
-							xConf.SetI("Server/GameplayOptions/"+sSettingName, iValue);
+							var string sPath = "Server/GameplayOptions/";
+							//Kr1s1m: Exception for AllowAlienCommands, since we can't put it inside GameplayOptions w/out editing the exe...
+							if(sSettingName=="AllowAlienCommands")then sPath="Server/";/*Kr1s1m: ...path hardcoded in exe*/ endif;
+							xConf.SetI(sPath+sSettingName, iValue);
 							CGameWrap.GetGame().SetAttrib(sSettingName, iValue);
 							//KLog.LogSpam("Kr1s1m", "CGameWrap.GetGame().SetAttrib("+sSettingName+", "+iValue.ToString()+")");
 						endfor;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/CustomMapMirageSettings.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/CustomMapMirageSettings.txt
@@ -26,6 +26,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						DivideSkulls = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '1'
@@ -75,6 +76,7 @@ Root {
 						AuraSharing = '1'
 						AttackInFOW = '0'
 						OldDisembark = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '2'
@@ -128,6 +130,7 @@ Root {
 						AuraSharing = '1'
 						AttackInFOW = '0'
 						OldDisembark = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '2'
@@ -181,6 +184,7 @@ Root {
 						AuraSharing = '1'
 						AttackInFOW = '0'
 						OldDisembark = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '1'
@@ -228,6 +232,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						DivideSkulls = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '2'
@@ -275,6 +280,7 @@ Root {
 						AuraSharing = '1'
 						AttackInFOW = '0'
 						OldDisembark = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '2'
@@ -327,6 +333,7 @@ Root {
 						AuraSharing = '1'
 						AttackInFOW = '0'
 						OldDisembark = '1'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -377,6 +384,7 @@ Root {
 						AuraSharing = '1'
 						AttackInFOW = '0'
 						OldDisembark = '1'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -422,6 +430,7 @@ Root {
 						AuraSharing = '1'
 						AttackInFOW = '0'
 						OldDisembark = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '1'
@@ -462,6 +471,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						AttackInFOW = '0'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -501,6 +511,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						DivideSkulls = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '1'
@@ -551,6 +562,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						AttackInFOW = '0'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -600,6 +612,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						AttackInFOW = '0'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '2'
@@ -647,6 +660,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						AttackInFOW = '0'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -697,6 +711,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						AttackInFOW = '0'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -732,6 +747,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						DivideSkulls = '1'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -774,6 +790,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						AttackInFOW = '0'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -819,6 +836,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						DivideSkulls = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '2'
@@ -867,6 +885,7 @@ Root {
 						AllowThrow = '1'
 						AuraSharing = '1'
 						AttackInFOW = '0'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -903,6 +922,7 @@ Root {
 						ResourcesUnlimited = '1'
 						TreasureSharing = '0'
 						UseFM = '0'
+						AllowAlienCommands = '0'
 					}
 				}
 				Timer {
@@ -929,6 +949,7 @@ Root {
 					CheckBox {
 						TreasureSharing = '0'
 						DisableArtifactRelease = '1'
+						AllowAlienCommands = '0'
 					}
 					DropList {
 						DwnLvlSwitch = '0'


### PR DESCRIPTION
- added alien commands hard coded exception paths for reading and writing the AllowAlienCommands value in config due to inability to edit exe
- alien commands can now be successfully configured for custom maps like other mirage settings
- configured alien commands to be locked and disabled on certain multiplayer campaign maps