### PR TITLE
Newsticker message fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Locale/cz/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/cz/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Special"
 "_PN_MP_MULTI_HEROES";"Heroes"
 "_PN_MP_MULTI_ALLIES";"Allies of heroes"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"The pirate ship has sent you resources!"

--- a/GameFiles/Basic/Data/MIRAGE/Locale/de/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/de/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Special"
 "_PN_MP_MULTI_HEROES";"Heroes"
 "_PN_MP_MULTI_ALLIES";"Allies of heroes"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"The pirate ship has sent you resources!"

--- a/GameFiles/Basic/Data/MIRAGE/Locale/fr/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/fr/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Special"
 "_PN_MP_MULTI_HEROES";"Heroes"
 "_PN_MP_MULTI_ALLIES";"Allies of heroes"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"The pirate ship has sent you resources!"

--- a/GameFiles/Basic/Data/MIRAGE/Locale/hu/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/hu/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Special"
 "_PN_MP_MULTI_HEROES";"Heroes"
 "_PN_MP_MULTI_ALLIES";"Allies of heroes"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"The pirate ship has sent you resources!"

--- a/GameFiles/Basic/Data/MIRAGE/Locale/it/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/it/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Special"
 "_PN_MP_MULTI_HEROES";"Heroes"
 "_PN_MP_MULTI_ALLIES";"Allies of heroes"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"The pirate ship has sent you resources!"

--- a/GameFiles/Basic/Data/MIRAGE/Locale/pl/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/pl/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Special"
 "_PN_MP_MULTI_HEROES";"Heroes"
 "_PN_MP_MULTI_ALLIES";"Allies of heroes"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"The pirate ship has sent you resources!"

--- a/GameFiles/Basic/Data/MIRAGE/Locale/ru/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/ru/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Особый"
 "_PN_MP_MULTI_HEROES";"Герои"
 "_PN_MP_MULTI_ALLIES";"Союзники героев"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"Пиратское судно прислало вам ресурсы!"

--- a/GameFiles/Basic/Data/MIRAGE/Locale/uk/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/uk/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Special"
 "_PN_MP_MULTI_HEROES";"Heroes"
 "_PN_MP_MULTI_ALLIES";"Allies of heroes"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"The pirate ship has sent you resources!"

--- a/GameFiles/Basic/Data/MIRAGE/Locale/zh/Texts/mirage.ltf
+++ b/GameFiles/Basic/Data/MIRAGE/Locale/zh/Texts/mirage.ltf
@@ -757,3 +757,4 @@
 "_UI_PlLiWind_Option_Special";"Special"
 "_PN_MP_MULTI_HEROES";"Heroes"
 "_PN_MP_MULTI_ALLIES";"Allies of heroes"
+"_MIRAGE_NT_Single_06_PirateShip_Support";"The pirate ship has sent you resources!"

--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -1,5 +1,31 @@
 Change Log:
 
+MIRAGE 2.6.8
+------------------
+
+General:
+
+Maps:
+
+COOP campaign and maps with custom gameplay:
+
+Campaign maps:
+
+Heroes:
+
+Dustriders:
+
+Dragon Clan:
+
+Norsemen:
+
+SEAS:
+
+AI:
+
+SDK:
+- Fixed NewStickerMessage(NWTK) trigger issue. It wasnt loading up in user interface general game messages, only Help Messages. Now both available
+
 MIRAGE 2.6.7
 ------------------
 

--- a/GameFiles/Basic/Data/MIRAGE/Texts/mirage.lmf
+++ b/GameFiles/Basic/Data/MIRAGE/Texts/mirage.lmf
@@ -777,3 +777,4 @@
 "_UI_PlLiWind_Option_Special";"!mirage.ltf load failed!";50;""
 "_PN_MP_MULTI_HEROES";"!mirage.ltf load failed!";50;""
 "_PN_MP_MULTI_ALLIES";"!mirage.ltf load failed!";50;""
+"_MIRAGE_NT_Single_06_PirateShip_Support";"!mirage.ltf load failed!";50;""

--- a/GameFiles/Basic/Data/MIRAGE/leveled/Scripts/trigger/ViewActionCreate.usl
+++ b/GameFiles/Basic/Data/MIRAGE/leveled/Scripts/trigger/ViewActionCreate.usl
@@ -7300,7 +7300,8 @@ class CActionNewsTicker inherit CActionPages
 			for(i=0)cond(i<iC)iter(i++)do
 				var string sKey;
 				if(CLocalizer.Get().GetKey(i,sKey))then
-					if(sKey.Left(7)=="_NTMSG_")then
+//					if(sKey.Left(7)=="_NTMSG_")then
+					if(sKey.Find("_NT_")!=-1)then
 						m_pxMessage^.AddItem(CLocalizer.Get().Translate(sKey),new CMessageItemData(sKey));
 					endif;
 				endif;


### PR DESCRIPTION
* Fixed typo in the NewStickerMessage config string names which were causing the General NewStciker Messages not loading up for Trigger in User SDK Interface. Both base Game and MIRAGE messages supported from now on;
* Added additional NewStickerMessage, specific for MultiplayerCampaign Mission 6;
* Added template for future public release;
* Added NWTK fix;