### PR TITLE
Revert "ConditionFactory: MakeQuery should skip uninteractable fight objects (REGN fix)"

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/misc/ConditionFactory.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/misc/ConditionFactory.usl
@@ -651,15 +651,7 @@ class CObjFinder
 			var int i, iC = po_rxObjs.NumEntries();
 			for(i=0) cond(i<iC) iter(++i)do
 				var ^CGameObj pxO = po_rxObjs[i].GetObj();
-				var ^CFightingObj pxFO = cast<CFightingObj>(pxO);
-				var bool bUninteractable = false;
-				//var bool bCorpse = false;
-				if(pxFO!=null)then
-					bUninteractable = !pxFO^.IsSelectable() || !pxFO^.IsHitable() || pxFO^.GetLDInvulnerable();
-					//bCorpse = pxFO^.m_xCorpse.IsValid() || pxFO^.m_xCorpse.GetObj() != null;
-				endif;
-				var bool bSkipFO = bUninteractable; //|| bCorpse;
-				if(cast<CVirtualProduceUnit>(pxO)!=null || bSkipFO)then
+				if(cast<CVirtualProduceUnit>(pxO)!=null) then
 					po_rxObjs.DeleteEntry(i--);
 					--iC;
 				endif;


### PR DESCRIPTION
Reverts Tatsukio/MIRAGE#347
- (From #347) TODO: Test if this (MakeQuery modification) causes issues with other condition triggers (the fix is intended to cure REGN - Region condition trigger at its root - MakeQuery) due to MakeQuery, which is used all over ConditionFactory, now making all condition triggers skip uninteractable objects from their queries (which currently seems like a wanted effect). If that effect is not wanted, make it so that only REGN and all triggers which need to skip uninteractable objects do so.
- Mission 1 has invulnerable dilo on first quest and potentially other issues. The revert commit from this branch fixes the issue. Mission 6 probably goes back to being broken. Needs testing!