### PR TITLE
Revert "added condition which acts as special object for PLDE"

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/misc/ConditionFactory.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/misc/ConditionFactory.usl
@@ -2189,11 +2189,6 @@ class CConditionPlayerDead inherit CTrigger.ICondition
 
 			if(ms_asValidTypes.FindEntry(pxFightingObj^.GetType().AsString())==-1)then return true; endif;
 			
-			//Kr1s1m: CFightingObj with not selectable, not hitable or invulnerable (from trigger) flags...
-			//Kr1s1m: ...are exceptions (special object) when it comes to Player Dead (PLDE).
-			//Kr1s1m: Used for burning invulnerable buildings in campaign. Works with any combinations of the flags.
-			if(!pxFightingObj^.IsSelectable() || !pxFightingObj^.IsHitable() || pxFightingObj^.GetLDInvulnerable())then return true; endif;
-			
 			if(m_iMode==CConditionPlayerDead.BUILDING_MODE && !m_bCheckPyramid)then
 				var CObjList xList;
 				CBLDGMgr.Get().GetAllBuildings(m_iPlayer,xList);


### PR DESCRIPTION
Reverts Tatsukio/MIRAGE#141

- this should be reverted when a better way to keep cutscene buildings on map is implemented