### PR TITLE
Fixed AI Help message

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -9,7 +9,7 @@ General:
 Maps:
 
 COOP campaign and maps with custom gameplay:
-- Ally control available on missions 5, 11, 16 and B42
+ - Ally control available on missions 5, 11, 16 and B42
 
 Campaign maps:
 
@@ -24,10 +24,11 @@ Norsemen:
 SEAS:
 
 AI:
+ - Restored ability to call AI for help. If AI allied AI able, it will send up reinforcements and infrom Player about it. To request it in the Chat Droplist select Allied AI Player which you want ask for help. And type in chat "help" or "Help" as exact match, except "". Note, that typing for All allied players same message wont work.
 
 SDK:
-- Fixed NewStickerMessage(NWTK) trigger issue. It wasnt loading up in user interface general game messages, only Help Messages. Now both available
-- Added player handicap(HP) option for Custom map control options
+ - Fixed NewStickerMessage(NWTK) trigger issue. It wasnt loading up in user interface general game messages, only Help Messages. Now both available
+ - Added player handicap(HP) option for Custom map control options
 
 MIRAGE 2.6.7
 ------------------

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/ChatWindow.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/ChatWindow.usl
@@ -151,8 +151,9 @@ class CIngameChatBar inherit CStaticCtrlEx
 							if(bMatch)then
 								if(pxPlayerSlot^.IsAIPlayer())then
 									var string sAISlot = "AI" + pxPlayerSlot^.GetPlayerSlotID().ToString() + ": ";
-									sMsg.Replace("[" + sTime + "] ","");
-									CEvt_AiGenericStringEvent.Send(iPlayerID.ToString()+" "+ sAISlot + sMsg);
+									var string sCommand = sMsg;
+									sCommand.Replace("[" + sTime + "] ","");
+									CEvt_AiGenericStringEvent.Send(iPlayerID.ToString()+" "+ sAISlot + sCommand);
 								endif;
 								if(bCustomName)then
 									WhisperTo(pxPlayerSlot^.GetOwner(),CLocalizer.Get().Translate(pxPlayerSlot^.GetName()),sMsg,pxPlayerSlot^.GetOwner());

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/ChatWindow.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/ChatWindow.usl
@@ -151,6 +151,7 @@ class CIngameChatBar inherit CStaticCtrlEx
 							if(bMatch)then
 								if(pxPlayerSlot^.IsAIPlayer())then
 									var string sAISlot = "AI" + pxPlayerSlot^.GetPlayerSlotID().ToString() + ": ";
+									sMsg.Replace("[" + sTime + "] ","");
 									CEvt_AiGenericStringEvent.Send(iPlayerID.ToString()+" "+ sAISlot + sMsg);
 								endif;
 								if(bCustomName)then


### PR DESCRIPTION
* Because time when message was sent had been added to message text, AI functions were skipping specific commands that player were sending them through messages. This has been fixed;
* Added guide to Readme.txt how to use AI Call for Help command;