### PR TITLE
Host Slot Map Difficulty Default value

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -14,6 +14,7 @@ Maps:
 
 COOP campaign and maps with custom gameplay:
  - Ally control available on missions 5, 11, 16 and B42
+ - On CRASH RPG Map Host Difficulty default value is 9 from now on
 
 Campaign maps:
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PlayerInfoSlot.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PlayerInfoSlot.usl
@@ -188,6 +188,7 @@ class CPlayerInfoSlot inherit CStaticCtrl
 		if(m_pxPlayerSlot!=null)then
 			var bool bOwn = (m_xPlayerSlotID == CGameWrap.GetClient().GetPlayerSlotID());
 			var bool bHost = (CGameWrap.GetClientID()==CMultiPlayerClientMgr.Get().GetHostID());
+			var bool bHostDifficculty = (m_iIndex==0 && CMirageClnMgr.HostDifficulty(CMultiPlayerClientMgr.Get().GetLevelInfo()));
 			var bool bAiPlayer = m_sType.Left(3)=="ai_";
 			var bool bResetArmy = false;
 			var int iNewCredits = CGameWrap.GetClient().GetGame().GetCredits();
@@ -207,6 +208,12 @@ class CPlayerInfoSlot inherit CStaticCtrl
 				if(bOwn)then
 					bResetArmy = true;
 				endif;
+			endif;
+			if(bHost&&bHostDifficculty&&m_pxPlayerSlot^.GetValue("Difficulty").IsEmpty())then
+				m_pxPlayerSlot^.SetValue("Difficulty",9);
+				CGameWrap.GetGame().SetAttrib("HostDifficulty",9);
+			elseif(bHostDifficculty&&CGameWrap.GetGame().GetAttribInt("HostDifficulty")!=m_pxPlayerSlot^.GetValueInt("Difficulty"))then
+				m_pxPlayerSlot^.SetValue("Difficulty",9);
 			endif;
 			m_iDifficulty = m_pxPlayerSlot^.GetValueInt("Difficulty");
 			if(m_sTribe!=m_pxPlayerSlot^.GetTribe())then
@@ -1613,6 +1620,9 @@ class CPlayerInfoSlot inherit CStaticCtrl
 	proc bool OnChangeDifficulty()
 		m_iDifficulty=m_pxDifficultyDropList^.GetSelectedItem();
 		//KLog.LogSpam("ParaworldFan","PlayerInfoSlot: OnChangeDifficulty() m_iDifficulty=="+m_iDifficulty.ToString()+" for PlayerSlot_"+m_pxPlayerSlot^.GetPlayerSlotID().ToString());
+		if(m_iIndex==0&&CMirageClnMgr.HostDifficulty(CMultiPlayerClientMgr.Get().GetLevelInfo()))then
+			CGameWrap.GetGame().SetAttrib("HostDifficulty",m_pxDifficultyDropList^.GetSelectedItem());
+		endif;
 		if(m_pxPlayerSlot!=null)then
 			m_pxPlayerSlot^.SetValue("Difficulty",m_pxDifficultyDropList^.GetSelectedItem());
 		endif;


### PR DESCRIPTION
* Changed default value for Map Difficulty which is set in Host Player Slot. Value changed from 0 to 9. Currently used only in one map – CRASH RPG;