### PR TITLE
Disabled revealing in MultiplayerCampaign

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -15,6 +15,7 @@ Maps:
 COOP campaign and maps with custom gameplay:
  - Ally control available on missions 5, 11, 16 and B42
  - On CRASH RPG Map Host Difficulty default value is 9 from now on
+ - Disabled revealing for remaining player units after all HQ's are destroyed for Multiplayer Campaign mode
 
 Campaign maps:
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/misc/GameOverMgr.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/misc/GameOverMgr.usl
@@ -135,10 +135,11 @@ class CGameOverMgr inherit CEvtSink
 		xOQ.Execute(m_xDominationPoints);
 		var ^CLevelInfoHost pxLevelInfo=^(m_pxLevel^.GetLevelInfo());
 		var ^CPropDB pxGenericDB=^(pxLevelInfo^.GetGenericData());
+		var string sLevelName=(pxGenericDB^)["Base/LevelName"].Value();
 		begin CheckMultiplayer;
 			var ^CPropDB.CNode pxMapType=pxGenericDB^.FindNode("Base/MapType",false);
 			if(pxMapType!=null)then
-				if(pxMapType^.Value()=="multiplayer")then
+				if(pxMapType^.Value()=="multiplayer"&&!CMirageSrvMgr.Get().CheckCustomMap(sLevelName,"MultiplayerCampaign"))then
 					m_bEnabled=true;
 				endif;
 			endif;
@@ -147,7 +148,7 @@ class CGameOverMgr inherit CEvtSink
 			m_bEnabled=CCrashRPGMgr.GetCrashRPGMgr()^.GOMEnabled();
 		endif;
 		if(!m_bEnabled)then return; endif;
-		var bool bBfPW=CMirageSrvMgr.Get().GetMapNameSimple()=="_CU_MP_6_BFPW_HIGHLAND";
+		var bool bBfPW=sLevelName=="_CU_MP_6_BFPW_HIGHLAND";
 		var int i,iC=8;
 		if(m_axPlayerStates.NumEntries()!=8)then
 			m_axPlayerStates=iC;


### PR DESCRIPTION
* Disabled revealing and other basic game modes victory and defeat mechanics for MultiplayerCampaign mode. MultiplayerCampaign mode supports only trigger victory/defeat from now on, just like the original singleplayer campaign mode;