### PR TITLE
Boosterpack missions loadscreen music

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -18,6 +18,7 @@ COOP campaign and maps with custom gameplay:
  - Disabled revealing for remaining player units after all HQ's are destroyed for Multiplayer Campaign mode
 
 Campaign maps:
+- Added LoadScreen music for Tutorial, Devil's Advocate, Cold Day in Hell and in Operation Neptune
 - Fixed Mission 1: Temporarily disabled sequence "recreation" trigger nodes which were causing issues
 - Fixed Mission 2: Temporarily disabled sequence "recreation" trigger nodes which were causing issues
 - Fixed Mission 4: Temporarily disabled sequence "recreation" trigger nodes which were causing issues

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/LoadingScreens.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/LoadingScreens.txt
@@ -4,7 +4,7 @@ Root {
 			image = 'menue/decoration/loadbg_single00.jpg'
 			title = ''
 			text = ''
-			audio = '04_plain_northland_1'
+			audio = 'ds_1000_JOURNAL_ENTRY_(EMPTY)_00'
 		}
 		single_01 {
 			image = 'menue/decoration/loadbg_single01.jpg'
@@ -106,37 +106,37 @@ Root {
 			image = 'menue/decoration/loadbg_singleb41.jpg'
 			title = '_db_JOURNAL_b41_title'
 			text = '_db_JOURNAL_b41_text'
-			audio = '44_var_plain_northland_1'
+			audio = 'ds_4101_JOURNAL_ENTRY_(LEIGHTON)_01'
 		}
 		single_b42 {
 			image = 'menue/decoration/loadbg_singleb42.jpg'
 			title = '_db_JOURNAL_b42_title'
 			text = '_db_JOURNAL_b42_text'
-			audio = '13_plain_icewaste'
+			audio = 'ds_4201_JOURNAL_ENTRY_(LEIGHTON)_02'
 		}
 		single_b43 {
 			image = 'menue/decoration/loadbg_singleb43.jpg'
 			title = '_db_JOURNAL_b43_title'
 			text = '_db_JOURNAL_b43_text'
-			audio = '11_plain_jungle_1'
+			audio = 'ds_4301_JOURNAL_ENTRY_(KLEEMAN)_01'
 		}
 		single_b41_seas {
 			image = 'menue/decoration/loadbg_singleb41.jpg'
 			title = '_db_JOURNAL_b41_title'
 			text = '_db_JOURNAL_b41_text'
-			audio = '44_var_plain_northland_1'
+			audio = 'ds_4101_JOURNAL_ENTRY_(LEIGHTON)_01'
 		}
 		single_b42_seas {
 			image = 'menue/decoration/loadbg_singleb42.jpg'
 			title = '_db_JOURNAL_b42_title'
 			text = '_db_JOURNAL_b42_text'
-			audio = '13_plain_icewaste'
+			audio = 'ds_4201_JOURNAL_ENTRY_(LEIGHTON)_02'
 		}
 		single_b43_seas {
 			image = 'menue/decoration/loadbg_singleb43.jpg'
 			title = '_db_JOURNAL_b43_title'
 			text = '_db_JOURNAL_b43_text'
-			audio = '11_plain_jungle_1'
+			audio = 'ds_4301_JOURNAL_ENTRY_(KLEEMAN)_01'
 		}
 		single_seas_01 {
 			image = 'menue/decoration/loadbg_seas1.jpg'

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/LoadingScreens.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/LoadingScreens.txt
@@ -4,7 +4,7 @@ Root {
 			image = 'menue/decoration/loadbg_single00.jpg'
 			title = ''
 			text = ''
-			audio = ''
+			audio = '04_plain_northland_1'
 		}
 		single_01 {
 			image = 'menue/decoration/loadbg_single01.jpg'
@@ -106,37 +106,37 @@ Root {
 			image = 'menue/decoration/loadbg_singleb41.jpg'
 			title = '_db_JOURNAL_b41_title'
 			text = '_db_JOURNAL_b41_text'
-			audio = ''
+			audio = '44_var_plain_northland_1'
 		}
 		single_b42 {
 			image = 'menue/decoration/loadbg_singleb42.jpg'
 			title = '_db_JOURNAL_b42_title'
 			text = '_db_JOURNAL_b42_text'
-			audio = ''
+			audio = '13_plain_icewaste'
 		}
 		single_b43 {
 			image = 'menue/decoration/loadbg_singleb43.jpg'
 			title = '_db_JOURNAL_b43_title'
 			text = '_db_JOURNAL_b43_text'
-			audio = ''
+			audio = '11_plain_jungle_1'
 		}
 		single_b41_seas {
 			image = 'menue/decoration/loadbg_singleb41.jpg'
 			title = '_db_JOURNAL_b41_title'
 			text = '_db_JOURNAL_b41_text'
-			audio = ''
+			audio = '44_var_plain_northland_1'
 		}
 		single_b42_seas {
 			image = 'menue/decoration/loadbg_singleb42.jpg'
 			title = '_db_JOURNAL_b42_title'
 			text = '_db_JOURNAL_b42_text'
-			audio = ''
+			audio = '13_plain_icewaste'
 		}
 		single_b43_seas {
 			image = 'menue/decoration/loadbg_singleb43.jpg'
 			title = '_db_JOURNAL_b43_title'
 			text = '_db_JOURNAL_b43_text'
-			audio = ''
+			audio = '11_plain_jungle_1'
 		}
 		single_seas_01 {
 			image = 'menue/decoration/loadbg_seas1.jpg'


### PR DESCRIPTION
* Added missing LoadScreen music for missions: tutorial, single_b41, single_b41_seas, single_b42, single_b42_seas, single_b43 and single_b43_seas