### PR TITLE
CustomMap Hidden Player Slot AIBehavior Invalid value fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/GameInfoWindow.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/GameInfoWindow.usl
@@ -124,7 +124,7 @@ class CLevelInfoView inherit CStaticCtrlEx
 			sDescription=CLocalizer.Get().Translate(m_pxMapInfo^.GetDescription());
 			
 			sSetting=CLocalizer.Get().Translate("_UI_GameInfo_Option_"+m_pxMapInfo^.GetLevelInfo().GetLevelSetting());
-			sMaxPlayers=m_pxMapInfo^.GetMaxPlayers().ToString();
+			sMaxPlayers=CMirageClnMgr.Get().GetPlayers(m_pxMapInfo^.GetMapName(),m_pxMapInfo^.GetMaxPlayers()).ToString();
 			var int iMapW,iMapH;
 			m_pxMapInfo^.GetLevelInfo().GetMapSize(iMapW,iMapH);
 			sMapSize=iMapW.ToString()+" x "+iMapH.ToString();

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/LevelSettingsPage.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/LevelSettingsPage.usl
@@ -269,6 +269,11 @@ class CLevelSettingsPage inherit CWindow
 		m_pxMaxPlayers^.Select(iIdx);
 		m_pxMaxPlayers^.SetDisabled(false);
 		m_pxMaxPlayers^.m_xOnChange=OnChangePlayers;
+		var int iFakeNumPlayers=CMirageClnMgr.Get().GetFakeNumPlayers(CMirageClnMgr.Get().GetMapName());
+		CGameWrap.GetGame().SetAttrib("ShowPlayers",iNumPlayers);
+		if(iNumPlayers<iFakeNumPlayers)then
+			iNumPlayers=iFakeNumPlayers;
+		endif;
 		CMultiPlayerClientMgr.Get().SetNumPlayers(iNumPlayers);
 		//-------------------------------
 	endproc;
@@ -405,7 +410,7 @@ class CLevelSettingsPage inherit CWindow
 		for(i=0)cond(i<iC)iter(i++)do
 			var ^CMapInfoList.CMapInfo pxMapInfo=^(m_pxMapInfoList^.GetMapInfo(i));
 //			CMirageClnMgr.DumpMapInfo(pxMapInfo);
-			if(pxMapInfo^.GetMaxPlayers()< iPlayers)then continue; endif;
+			if(CMirageClnMgr.Get().GetPlayers(pxMapInfo^.GetMapName(),pxMapInfo^.GetMaxPlayers())< iPlayers)then continue; endif;
 			if(!CMirageClnMgr.AllowMap(pxMapInfo,iPlayers))then continue; endif;
 			var string sGameType=pxMapInfo^.GetGameType();
 			if(iGameType==4)then
@@ -429,7 +434,7 @@ class CLevelSettingsPage inherit CWindow
 					continue;
 				endif;
 			endif;
-			var int iMaxPlayers=pxMapInfo^.GetMaxPlayers();
+			var int iMaxPlayers=CMirageClnMgr.Get().GetPlayers(pxMapInfo^.GetMapName(),pxMapInfo^.GetMaxPlayers());
 			var string sMapName=CLocalizer.Get().Translate(pxMapInfo^.GetMapName());
 			var string sSortText=iMaxPlayers.ToString()+sMapName;//temporär nur zum sortieren
 			var int iIdx=m_pxHostMapList^.AddItem(sSortText,new CHostListEntry(iMaxPlayers,sMapName));
@@ -994,6 +999,11 @@ class CLevelSettingsPageHost inherit CLevelSettingsPage
 		CGameWrap.GetGame().SetAttrib("NumTeams",CClientWrap.GetUserProfileValueI("Multiplayer/NumTeams",2));
 		CGameWrap.GetGame().SetAttrib("Credits",CClientWrap.GetUserProfileValueI("Multiplayer/Credits",-1));
 		var int iNumPlayers=CClientWrap.GetUserProfileValueI("Multiplayer/NumPlayers",2);
+		var int iFakeNumPlayers=CMirageClnMgr.Get().GetFakeNumPlayers(CMirageClnMgr.Get().GetMapName());
+		CGameWrap.GetGame().SetAttrib("ShowPlayers",iNumPlayers);
+		if(iNumPlayers<iFakeNumPlayers)then
+			iNumPlayers=iFakeNumPlayers;
+		endif;
 		CGameWrap.GetClient().GetLevelPreview().SetNumPlayers(iNumPlayers);
 		CMultiPlayerClientMgr.Get().SetNumPlayers(iNumPlayers);
 		m_bHostInit = true;
@@ -1172,6 +1182,11 @@ class CLevelSettingsPageHost inherit CLevelSettingsPage
 	proc bool OnChangePlayers()
 		super.OnChangePlayers();
 		var int iNumPlayers=m_pxMaxPlayers^.GetSelectedItemAsString().ToInt();
+		var int iFakeNumPlayers=CMirageClnMgr.Get().GetFakeNumPlayers(CMirageClnMgr.Get().GetMapName());
+		CGameWrap.GetGame().SetAttrib("ShowPlayers",iNumPlayers);
+		if(iNumPlayers<iFakeNumPlayers)then
+			iNumPlayers=iFakeNumPlayers;
+		endif;
 		CGameWrap.GetClient().GetLevelPreview().SetNumPlayers(iNumPlayers);
 		CMultiPlayerClientMgr.Get().SetNumPlayers(iNumPlayers);
 		return true;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PlayerInfoSlot.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PlayerInfoSlot.usl
@@ -234,7 +234,7 @@ class CPlayerInfoSlot inherit CStaticCtrl
 			if(m_iHP==0)then m_iHP=100; endif;
 			m_iHeadQuater = m_pxPlayerSlot^.GetHeadQuater();
 			//Updating PlayerSlot HeadQuater if necessary
-			if(CMirageClnMgr.Get().CheckCustomMap(m_sLevelName,"Players/Player_"+m_iSlotID.ToString()+"/AddIfEmpty") && m_pxPlayerSlot^.IsFree())then
+			if(CMirageClnMgr.Get().CheckCustomMap(m_sLevelName,"Players/Player_"+m_iSlotID.ToString()+"/AddIfEmpty") && (m_pxPlayerSlot^.IsFree() || !GetVisible()))then
 				//calling function for players that wasnt added in Lobby, but will be added in Game
 				m_pxOwner^.UpdateSlotHeadQuater(m_iSlotID, m_iHeadQuater);
 			endif;
@@ -246,11 +246,13 @@ class CPlayerInfoSlot inherit CStaticCtrl
 			begin check_HQ;
 				var int iMaxPlayers=0;
 				if(bHost)then
-					iMaxPlayers=CMirageClnMgr.Get().GetHostMapInfo()^.GetMaxPlayers();
+					iMaxPlayers=CMirageClnMgr.Get().GetPlayers(m_sLevelName,CMirageClnMgr.Get().GetHostMapInfo()^.GetMaxPlayers());
 				else
-					iMaxPlayers=CMultiPlayerClientMgr.Get().GetLevelInfo()^.GetMaxPlayers();
+					iMaxPlayers=CMirageClnMgr.Get().GetPlayers(m_sLevelName,CMultiPlayerClientMgr.Get().GetLevelInfo()^.GetMaxPlayers());
 				endif;
-				if(CMirageClnMgr.Get().CheckCustomMap(m_sLevelName,"Players/Player_"+m_iSlotID.ToString()+"/AddIfEmpty") && m_pxPlayerSlot^.IsFree() && (m_pxPlayerSlot^.GetPlayerSlotID()>=iMaxPlayers))then
+				var bool bHiddenPlayer = CMirageClnMgr.Get().CheckCustomMap(m_sLevelName,"Players/Player_"+m_iSlotID.ToString()+"/HiddenSlot");
+				var bool bForced = CMirageClnMgr.Get().CheckCustomMap(m_sLevelName,"Players/Player_"+m_iSlotID.ToString()+"/AddIfEmpty");
+				if((bForced || bHiddenPlayer) && (m_pxPlayerSlot^.IsFree() || m_pxPlayerSlot^.GetPlayerSlotID()>=iMaxPlayers))then
 					iMaxPlayers=8;
 				endif;
 				if(m_pxHQDropList^.NumItems()!=iMaxPlayers)then
@@ -816,7 +818,7 @@ class CPlayerInfoSlot inherit CStaticCtrl
 		endif;
 		//the next variable checks, if the server host's DifficultyDropList should be unlocked for custom maps
 		var bool bAiHack=bAiPlayer||(m_iIndex==0&&CMirageClnMgr.HostDifficulty(CMultiPlayerClientMgr.Get().GetLevelInfo()));
-		if(m_pxPlayerSlot!=null && (!bHiddenPlayer && !bAiHack))then
+		if(m_pxPlayerSlot!=null && !CMirageClnMgr.Get().IsCustomMap(m_sLevelName) && (!bHiddenPlayer && !bAiHack))then
 			//m_pxDifficultyDropList^.Select(5);
 			m_pxDifficultyDropList^.Select(0);
 			m_pxPlayerSlot^.SetValue("Difficulty",0);
@@ -1387,6 +1389,9 @@ class CPlayerInfoSlot inherit CStaticCtrl
 			if(m_bIsSkirmishMode)then
 				CMultiPlayerClientMgr.Get().OnLevelInfoUpdate();
 			endif;
+		endif;
+		if(m_iIndex==0)then
+			m_pxOwner^.SetHiddenSlotsReady(p_bReady);
 		endif;
 		return true;
 	endproc;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PlayerListWindow.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PlayerListWindow.usl
@@ -286,6 +286,10 @@ class CPlayerListWindow inherit CMapListWindow
 		var int iTmp = 0;
 		var string sTmp;
 		CSettings.Get("Game/RecentSettingsSkirmish/NumPlayers",iTmp);
+		var int iFakeNumPlayers=CMirageClnMgr.Get().GetFakeNumPlayers(CMirageClnMgr.Get().GetMapName());
+		if(iTmp<iFakeNumPlayers)then
+			iTmp=iFakeNumPlayers;
+		endif;
 		if(iTmp>0) then
 			m_pxLevelInfo^.SetNumPlayers(iTmp);
 			iTmp=0;
@@ -302,6 +306,10 @@ class CPlayerListWindow inherit CMapListWindow
 		var ^CLevelInfo pxLevelInfo=^(CGameWrap.GetClient().GetLevelPreview());
 		if(CGameWrap.GetClientID()==0 || m_bIsSkirmishMode)then
 			var int iNumPlayers=CClientWrap.GetUserProfileValueI("Multiplayer/NumPlayers",2);
+			var int iFakeNumPlayers=CMirageClnMgr.Get().GetFakeNumPlayers(CMirageClnMgr.Get().GetMapName());
+			if(iNumPlayers<iFakeNumPlayers)then
+				iNumPlayers=iFakeNumPlayers;
+			endif;
 			if(pxLevelInfo^.GetNumPlayers()!=iNumPlayers)then
 				pxLevelInfo^.SetNumPlayers(iNumPlayers);
 			endif;
@@ -353,23 +361,32 @@ class CPlayerListWindow inherit CMapListWindow
 		endif;
 		var bool bAllReady = true;
 		var int i,iC = 8;
-		iMax = m_pxLevelInfo^.GetNumPlayers();
+		iMax = CGameWrap.GetGame().GetAttribInt("ShowPlayers");
 		var bool bIsCountdown = false;
 		if(CGameWrap.GetClient().GetLevelPreview().GetAttribs().GetValueInt("Countdown")==42)then
 			bIsCountdown=true;
 		endif;
 		for(i=0)cond(i<iC)iter(i++)do
-			m_apxPlayerInfo[i]^.GetInfoFromLevelInfo();
+			var ^CLevelInfo.CPlayerSlot pxPlayerSlot=m_apxPlayerInfo[i]^.GetPlayerSlot();
+			if(pxPlayerSlot==null)then continue; endif;
+			var bool bHidden = (CMirageClnMgr.Get().GetCustomPlayerSettingInt(CMirageClnMgr.Get().GetMapName(),i.ToString(),"HiddenSlot")==1);
+			var bool bAiPlayer = pxPlayerSlot^.GetType().Left(3)=="ai_";
 			var bool bValid = i<iMax;
+			if(!bHidden)then
+				if(bValid && bAiPlayer && !m_apxPlayerInfo[i]^.GetVisible())then
+					pxPlayerSlot^.SetType("invalid");
+				endif;
+				m_apxPlayerInfo[i]^.SetVisible(bValid);
+			endif;
+			m_apxPlayerInfo[i]^.GetInfoFromLevelInfo();
 			if(bValid && !m_apxPlayerInfo[i]^.IsReady())then
 				if(bIsCountdown) then
-					m_apxPlayerInfo[i]^.GetPlayerSlot()^.SetReady(true);
+					pxPlayerSlot^.SetReady(true);
 					bAllReady=true;
 				else
 					bAllReady = false;
 				endif;
 			endif;
-			m_apxPlayerInfo[i]^.SetVisible(bValid);
 		endfor;
 		if(bAllReady) then
 			CGameWrap.GetGame().SetAttrib("GameMode","closedwaiting");
@@ -726,16 +743,15 @@ class CPlayerListWindow inherit CMapListWindow
 	endproc;
 	
 	export proc void UpdateSlotHeadQuater(int p_iCurSlotID, ref int p_riCurHQ)
-		var int iNumPlayers,iMaxPlayers;
+		var int iMaxPlayers,iNumPlayers=CGameWrap.GetGame().GetAttribInt("ShowPlayers");
 		if(CGameWrap.GetClientID()==CMultiPlayerClientMgr.Get().GetHostID())then
-			iNumPlayers=CClientWrap.GetUserProfileValueI("Multiplayer/NumPlayers",-1);
-			iMaxPlayers=CMirageClnMgr.Get().GetHostMapInfo()^.GetMaxPlayers();
+			iMaxPlayers=CMirageClnMgr.Get().GetPlayers(CMirageClnMgr.Get().GetMapName(),CMirageClnMgr.Get().GetHostMapInfo()^.GetMaxPlayers());
 		else
-			iNumPlayers=m_pxLevelInfo^.GetNumPlayers();
-			iMaxPlayers=m_pxLevelInfo^.GetMaxPlayers();
+			iMaxPlayers=CMirageClnMgr.Get().GetPlayers(CMirageClnMgr.Get().GetMapName(),m_pxLevelInfo^.GetMaxPlayers());
 		endif;
 		//KLog.LogSpam("ParaworldFan","PlayerListWindow: UpdateSlotHeadQuater() iNumPlayers=="+iNumPlayers.ToString());
 		//KLog.LogSpam("ParaworldFan","PlayerListWindow: UpdateSlotHeadQuater() iMaxPlayers=="+iMaxPlayers.ToString());
+		//KLog.LogSpam("ParaworldFan","PlayerListWindow: UpdateSlotHeadQuater() CurSlotID=="+p_iCurSlotID.ToString());
 		
 		if(iNumPlayers==iMaxPlayers)then return; endif;		//do nothing if all available Player Slots are visible in lobby
 		if(p_iCurSlotID>=iMaxPlayers)then return; endif;	//do nothing for an AI Player Slot that always hidden in lobby
@@ -749,8 +765,9 @@ class CPlayerListWindow inherit CMapListWindow
 		endfor;
 		//filling up an array with all taken by Users HQ's in lobby
 		for(iSlotID=0)cond(iSlotID<p_iCurSlotID)iter(iSlotID++)do	//count only the HQ's of the previous player slots from the current player slot
-			var ^CLevelInfo.CPlayerSlot pxSlot=m_apxPlayerInfo[iSlotID]^.GetPlayerSlot();
-			aiUserHQList.AddEntry(pxSlot^.GetHeadQuater());
+			var ^CLevelInfo.CPlayerSlot pxPlayerSlot=m_apxPlayerInfo[iSlotID]^.GetPlayerSlot();
+			if(pxPlayerSlot==null)then continue; endif;
+			aiUserHQList.AddEntry(pxPlayerSlot^.GetHeadQuater());
 			//KLog.LogSpam("ParaworldFan","PlayerListWindow: UpdateSlotHeadQuater() aiUserHQList["+iSlotID.ToString()+"]=="+aiUserHQList[iSlotID].ToString());
 		endfor;
 		//removing from an array taken HQ's
@@ -765,6 +782,25 @@ class CPlayerListWindow inherit CMapListWindow
 		endfor;
 		p_riCurHQ=aiAllHQList[0];
 		//KLog.LogSpam("ParaworldFan","PlayerListWindow: UpdateSlotHeadQuater() p_riCurHQ="+p_riCurHQ.ToString()+" for PlayerSlot_"+p_iCurSlotID.ToString());
+	endproc;
+	
+	export proc void SetHiddenSlotsReady(bool p_bReady)
+		var int i,iC = 8;
+		for(i=0)cond(i<iC)iter(i++)do
+			var ^CLevelInfo.CPlayerSlot pxPlayerSlot=m_apxPlayerInfo[i]^.GetPlayerSlot();
+			if(pxPlayerSlot==null)then continue; endif;
+			var bool bVisible = m_apxPlayerInfo[i]^.GetVisible();
+			var bool bForced = ((pxPlayerSlot^.IsFree()||!bVisible) && CMirageClnMgr.Get().GetCustomPlayerSettingInt(CMirageClnMgr.Get().GetMapName(),i.ToString(),"AddIfEmpty")==1);
+			var bool bHidden = (CMirageClnMgr.Get().GetCustomPlayerSettingInt(CMirageClnMgr.Get().GetMapName(),i.ToString(),"HiddenSlot")==1);
+			var bool bCustom = (bForced||bHidden);
+			if(bCustom&&(p_bReady!=m_apxPlayerInfo[i]^.IsReady()))then
+				var bool bAiPlayer = pxPlayerSlot^.GetType().Left(3)=="ai_";
+				if(pxPlayerSlot^.IsFree()&&!bAiPlayer)then
+					pxPlayerSlot^.SetType("ai_Mikrobe");
+				endif;
+				pxPlayerSlot^.SetReady(p_bReady);
+			endif;
+		endfor;
 	endproc;
 	
 	proc bool OnBack()

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/MirageClnMgr.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/MirageClnMgr.usl
@@ -750,6 +750,40 @@ class CMirageClnMgr
 		return true;
 	endproc;
 	
+	export proc int GetPlayers(string p_sLevelName, int p_iPlayers)
+		//KLog.LogSpam("ParaworldFan", "MirageClnMgr:GetPlayers("+p_sLevelName+"), ("+p_iPlayers.ToString()+") begin");
+		if(!IsCustomMap(p_sLevelName))then return p_iPlayers; endif;
+		return p_iPlayers-GetHiddenPlayers(p_sLevelName);
+	endproc;
+	
+	export proc int GetHiddenPlayers(string p_sLevelName)
+		//KLog.LogSpam("ParaworldFan", "MirageClnMgr:GetHiddenPlayers("+p_sLevelName+") begin");
+		var int iNumPlayers=0;
+		if(m_pxCustomMapSettingsDB==null || p_sLevelName.IsEmpty())then return iNumPlayers; endif;
+		p_sLevelName.Replace(" ","_");
+		var string sPath="Levels/"+p_sLevelName+"/Custom/Players";
+		var int iSlotID,iNumSlots=8;
+		for(iSlotID=0)cond(iSlotID<iNumSlots)iter(iSlotID++)do
+			var ^CPropDB.CNode pxPlayerNode=m_pxCustomMapSettingsDB^.FindNode(sPath+"/Player_"+iSlotID.ToString()+"/HiddenSlot",false);
+			if(pxPlayerNode!=null)then iNumPlayers++; endif;
+		endfor;
+		//KLog.LogSpam("ParaworldFan","MirageClnMgr:GetHiddenPlayers iNumPlayers="+iNumPlayers.ToString());
+		return iNumPlayers;
+	endproc;
+	
+	export proc int GetFakeNumPlayers(string p_sLevelName)
+		var int iNumPlayers=0;
+		if(m_pxCustomMapSettingsDB==null || p_sLevelName.IsEmpty())then return iNumPlayers; endif;
+		p_sLevelName.Replace(" ","_");
+		var string sPath="Levels/"+p_sLevelName+"/Custom/Players";
+		var int iSlotID,iNumSlots=8;
+		for(iSlotID=0)cond(iSlotID<iNumSlots)iter(iSlotID++)do
+			var ^CPropDB.CNode pxPlayerNode=m_pxCustomMapSettingsDB^.FindNode(sPath+"/Player_"+iSlotID.ToString(),false);
+			if(pxPlayerNode!=null)then iNumPlayers++; endif;
+		endfor;
+		return iNumPlayers;
+	endproc;
+	
 	export proc bool IsCustomMap(string p_sLevelName)
 		var bool bCustom = false;
 		if(m_pxCustomMapSettingsDB!=null)then

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/MultiplayerClientMgr.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/mgr/MultiplayerClientMgr.usl
@@ -211,6 +211,10 @@ class CMultiPlayerClientMgr
 			var string sPath = m_pxLevelInfo^.GetAttribs().GetValue("Name");
 			var int iLockDiplomacySettings = m_pxLevelInfo^.GetAttribs().GetValueInt("LockDiplomacySettings");
 			if(CGameWrap.GetClientID()!=GetHostID() && iNumPlayers>0)then
+				var int iFakeNumPlayers=CMirageClnMgr.Get().GetFakeNumPlayers(CMirageClnMgr.Get().GetMapName());
+				if(iNumPlayers<iFakeNumPlayers)then
+					iNumPlayers=iFakeNumPlayers;
+				endif;
 				SetNumPlayers(iNumPlayers);
 			endif;
 			var CIOPath xPath;
@@ -438,6 +442,10 @@ class CMultiPlayerClientMgr
 		m_bSkirmishMode=p_bParam;
 		if(p_bParam) then
 			CSettings.Get("Game/RecentSettingsSkirmish/NumPlayers",m_iNumPlayers);
+			var int iFakeNumPlayers=CMirageClnMgr.Get().GetFakeNumPlayers(CMirageClnMgr.Get().GetMapName());
+			if(m_iNumPlayers<iFakeNumPlayers)then
+				m_iNumPlayers=iFakeNumPlayers;
+			endif;
 		endif;
 		return(true);
 	endproc;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/CustomMapSettings.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/CustomMapSettings.txt
@@ -52,41 +52,25 @@ Root {
 						HP = '120'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_6 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_7 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -144,42 +128,22 @@ Root {
 						HP = '130'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						HP = '200'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_5 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_6 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_7 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -235,41 +199,29 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_7 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -286,7 +238,7 @@ Root {
 					ChooseColor = '0'
 				}
 				DropList {
-					NumTeams = '4'
+					NumTeams = '5'
 					Credits = '204'
 				}
 			}
@@ -327,41 +279,33 @@ Root {
 						HP = '120'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -417,41 +361,33 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -507,41 +443,33 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -599,41 +527,33 @@ Root {
 						HP = '120'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -691,41 +611,33 @@ Root {
 						HP = '120'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -742,7 +654,7 @@ Root {
 					ChooseColor = '0'
 				}
 				DropList {
-					NumTeams = '3'
+					NumTeams = '4'
 					Credits = '209'
 				}
 			}
@@ -783,39 +695,28 @@ Root {
 						HP = '200'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_7 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
 						HiddenSlot = '1'
@@ -875,41 +776,29 @@ Root {
 						HP = '130'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_7 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -965,41 +854,33 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1055,41 +936,29 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_7 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1106,7 +975,7 @@ Root {
 					ChooseColor = '0'
 				}
 				DropList {
-					NumTeams = '3'
+					NumTeams = '4'
 					Credits = '213'
 				}
 			}
@@ -1147,12 +1016,10 @@ Root {
 						HP = '130'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
@@ -1161,26 +1028,21 @@ Root {
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1197,7 +1059,7 @@ Root {
 					ChooseColor = '0'
 				}
 				DropList {
-					NumTeams = '8'
+					NumTeams = '5'
 					Credits = '214'
 				}
 			}
@@ -1250,36 +1112,29 @@ Root {
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1335,7 +1190,6 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Aje = ''
@@ -1347,17 +1201,14 @@ Root {
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Aje = ''
@@ -1369,7 +1220,6 @@ Root {
 					Player_4 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Aje = ''
@@ -1380,17 +1230,14 @@ Root {
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1407,7 +1254,7 @@ Root {
 					ChooseColor = '0'
 				}
 				DropList {
-					NumTeams = '3'
+					NumTeams = '2'
 					Credits = '216'
 				}
 			}
@@ -1446,7 +1293,6 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Aje = ''
@@ -1458,7 +1304,6 @@ Root {
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Aje = ''
@@ -1471,7 +1316,6 @@ Root {
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Aje = ''
@@ -1483,7 +1327,6 @@ Root {
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Aje = ''
@@ -1494,22 +1337,18 @@ Root {
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1567,7 +1406,6 @@ Root {
 						HP = '120'
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Hu = '_PN_SP00_Barbarian'
@@ -1582,36 +1420,25 @@ Root {
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
-						HiddenSlot = '1'
-					}
-					Player_7 {
-						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1667,7 +1494,6 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Hu = '_PN_SP07_PLAYER03'
@@ -1682,7 +1508,6 @@ Root {
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Hu = '_PN_SP09_PLAYER04'
@@ -1697,31 +1522,25 @@ Root {
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1777,7 +1596,6 @@ Root {
 					Player_0 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
 								Ninigi = '_PN_SP07_PLAYER05'
@@ -1792,26 +1610,21 @@ Root {
 					Player_1 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_2 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_3 {
 						CampaignAI = '1'
 						AddIfEmpty = '1'
-						HiddenSlot = '1'
 					}
 					Player_4 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_5 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 						Exceptions {
 							PlayerName {
@@ -1826,12 +1639,10 @@ Root {
 					}
 					Player_6 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 					Player_7 {
 						CampaignAI = '1'
-						AddIfEmpty = '1'
 						HiddenSlot = '1'
 					}
 				}
@@ -1947,6 +1758,24 @@ Root {
 				}
 				EnableQuests = '1'
 				Players {
+					Player_0 {
+						AddIfEmpty = '1'
+					}
+					Player_1 {
+						AddIfEmpty = '1'
+					}
+					Player_2 {
+						AddIfEmpty = '1'
+					}
+					Player_3 {
+						AddIfEmpty = '1'
+					}
+					Player_4 {
+						AddIfEmpty = '1'
+					}
+					Player_5 {
+						AddIfEmpty = '1'
+					}
 					Player_6 {
 						HiddenSlot = '1'
 					}

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/ServerApp.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/ServerApp.usl
@@ -279,8 +279,7 @@ class CServerApp inherit IServerApp
 		var ^CLevel pxLevel=CSrvWrap.GetCurLevel();
 		System.Assert(pxLevel!=null);					   
 		var ^CLevelInfo pxLevelInfo=^(pxLevel^.GetLevelInfo());
-		var ^CPropDB pxGenericDB=^(pxLevelInfo^.GetGenericData());
-		var string sLevelName = (pxGenericDB^)["Base/LevelName"].Value();
+		var string sLevelName=(pxLevelInfo^.GetGenericData())["Base/LevelName"].Value();
 		if(pxLevelInfo^.IsMultiplayer()&&!CMirageSrvMgr.Get().CheckCustomMap(sLevelName,"EndScreen/CampaignScreen"))then
 			CGameOverMgr.Get().OnAbandonGame(p_iOwner);
 		else
@@ -378,7 +377,8 @@ class CServerApp inherit IServerApp
 		var ^CLevelInfo pxLevelInfo=^(p_pxLevel^.GetLevelInfo());
 		var ^CPropDB pxGenericDB=^(pxLevelInfo^.GetGenericData());
 		//pxGenericDB^.Save("c:/LevelInfo_Vor.txt");
-		var string sLevelName = (pxGenericDB^)["Base/LevelName"].Value();
+		var ^CPropDB.CNode pxBaseNode=^((pxGenericDB^)["Base"]);
+		var string sLevelName=pxBaseNode^.GetValueS("LevelName");
 		var string sLNFHCTTF = sLevelName; // Henry: LevelNameForHardCodedTechTreeFilters
 		sLNFHCTTF.Replace(" ","_");
 		sLNFHCTTF.MakeLower();
@@ -387,20 +387,20 @@ class CServerApp inherit IServerApp
 		var bool bRandomColor=(CSrvWrap.GetGame().GetAttribInt("RandomColor")==1);
 		var bool bMultiplayer=true;
 		begin GetMultiplayer;
-			var ^CPropDB.CNode pxMapType=pxGenericDB^.FindNode("Base/MapType",false);
+			var ^CPropDB.CNode pxMapType=pxBaseNode^.FindNode("MapType",false);
 			if(pxMapType!=null)then
 				bMultiplayer=(pxMapType^.Value()=="multiplayer");
 			endif;
 		end GetMultiplayer;
-		var int iMaxPlayers=(pxGenericDB^)["Base/MaxPlayers"].ValueI();
-		var int iRandomHQFlag=(pxGenericDB^)["Base/RandomHQFlag"].ValueI();
-		var int iRandomColorFlag=(pxGenericDB^)["Base/RandomColorFlag"].ValueI();
+		var int iMaxPlayers=pxBaseNode^.GetValueI("MaxPlayers");
+		var int iRandomHQFlag=pxBaseNode^.GetValueI("RandomHQFlag");
+		var int iRandomColorFlag=pxBaseNode^.GetValueI("RandomColorFlag");
 		var string sValue;
 		if(CMirageSrvMgr.Get().GetCustomSettingS(sLevelName,"random_hq",sValue)&&pxLevelInfo^.IsMultiplayer())then	//gets "RandomHq" value from external config file "custom_level_data.txt"
 			bRandomHQ = sValue=="1";	//sets availability of Random Server Option on the currently loading map
 		endif;
 		if(bRandomHQ && bMultiplayer && iRandomHQFlag==0 && iMaxPlayers>0)then
-			(pxGenericDB^)["Base"].SetValue("RandomHQFlag",1);
+			pxBaseNode^.SetValue("RandomHQFlag",1);
 			var array int aiAllHQList;
 			var array CPlayerHQInfo axPlayerHQInfoList;
 			var int i;
@@ -437,7 +437,7 @@ class CServerApp inherit IServerApp
 			endfor;
 		endif;
 		if(bRandomColor && !CMirageSrvMgr.Get().CheckCustomMap(sLevelName,"PlayerColor") && bMultiplayer && iRandomColorFlag==0)then
-			(pxGenericDB^)["Base"].SetValue("RandomColorFlag",1);
+			pxBaseNode^.SetValue("RandomColorFlag",1);
 			var array int aiAllColorList;
 			var array CPlayerColorInfo axPlayerColorInfoList;
 			var int i;
@@ -539,12 +539,9 @@ class CServerApp inherit IServerApp
 			endif;
 			//pxWalk^.SetOwner(iOwner);
 			var string sType=pxWalk^.GetType();
-			//fixing "invalid" Behaviour Type for AI players on hidden player slots for CUSTOM maps
-			if(sType!="human" && CMirageSrvMgr.Get().IsSlotForced(sLevelName,i) && CMirageSrvMgr.Get().CheckCustomMap(sLevelName,"Players/Player_"+i.ToString()+"/AddIfEmpty") && pxLevelInfo^.IsMultiplayer())then
-				sType="ai_Mikrobe";
-				pxWalk^.SetType(sType);
-			endif;
-			//
+			var ^CPropDB.CNode pxPlayerNode=^((pxGenericDB^)["PlayerSettings/Player_"+iHQ.ToString()]);
+			var ^CPropDB.CNode pxRestrictionsNode=pxPlayerNode^.Get("Restrictions");
+			var ^CPropDB.CNode pxPlayerBaseNode=pxRestrictionsNode^.Get("Base");
 			begin CheckRandomTribe;
 				var string sTribe=pxWalk^.GetTribe();
 				var bool bServerUpdate=false, bCustom=false, bAI=sType.Left(3)=="ai_";
@@ -557,8 +554,8 @@ class CServerApp inherit IServerApp
 				if(pxGame!=null)then
 					var int iCredits=pxGame^.GetCredits();
 					if(sType=="human"||bCustom||bAI)then
-						var string sAllTribes = (pxGenericDB^)["PlayerSettings/Player_"+iHQ.ToString()+"/Restrictions/Base/Tribes"].Value();
-						var ^CPropDB.CNode pxTribesNode=^((pxGenericDB^)["PlayerSettings/Player_"+iHQ.ToString()+"/Restrictions/Base/Tribes"]);
+						var string sAllTribes = pxPlayerBaseNode^.GetValueS("Tribes");
+						var ^CPropDB.CNode pxTribesNode=pxPlayerBaseNode^.Get("Tribes");
 						var string sTrb=pxGame^.GetAttrib("true_tribe_"+i.ToString());
 						bServerUpdate=(asValidFilters.FindEntry(sTrb)!=-1 || sAllTribes.Find(sTribe) == -1)&&pxLevelInfo^.IsMultiplayer();
 						if(bServerUpdate)then
@@ -606,7 +603,7 @@ class CServerApp inherit IServerApp
 									sNode+=iCredits.ToString()+sTribeSmall;
 									var ^CPropDB.CNode pxPNU=xPDB.FindNode(sNode+"/Units",false);
 									if(pxPNU!=null)then
-										var ^CPropDB.CNode pxPointBuyPreset = pxGenericDB^.FindNode("PlayerSettings/Player_"+iHQ.ToString()+"/PointBuyPreset/"+sTribe,true);
+										var ^CPropDB.CNode pxPointBuyPreset = pxPlayerNode^.FindNode("PointBuyPreset/"+sTribe,true);
 										if(pxPointBuyPreset!=null)then
 											pxPointBuyPreset^.Clear();
 											pxPointBuyPreset^.Join(pxPNU);
@@ -614,7 +611,7 @@ class CServerApp inherit IServerApp
 									endif;
 									var ^CPropDB.CNode pxPNR=xPDB.FindNode(sNode+"/Resources",false);
 									if(pxPNR!=null)then
-										var ^CPropDB.CNode pxPointBuyPreset = pxGenericDB^.FindNode("PlayerSettings/Player_"+iHQ.ToString()+"/Restrictions/Resources",true);
+										var ^CPropDB.CNode pxPointBuyPreset = pxPlayerBaseNode^.FindNode("Resources",true);
 										if(pxPointBuyPreset!=null)then
 											pxPointBuyPreset^.Clear();
 											pxPointBuyPreset^.Join(pxPNR);
@@ -626,7 +623,7 @@ class CServerApp inherit IServerApp
 					endif;
 				endif;
 				if(sTribe=="Random")then
-					var ^CPropDB.CNode pxTribesNode=^((pxGenericDB^)["PlayerSettings/Player_"+iHQ.ToString()+"/Restrictions/Base/Tribes"]);
+					var ^CPropDB.CNode pxTribesNode=pxPlayerBaseNode^.Get("Tribes");
 					sTribe=pxTribesNode^.GetValueS("Tribe2Use","Hu");
 					pxWalk^.SetTribe(sTribe);
 				endif;
@@ -772,7 +769,7 @@ class CServerApp inherit IServerApp
 				pxWalk^.SetTeam(iTemp);
 			endif;
 			pxPlayer^.Init();
-			var ^CPropDB.CNode pxNodeBase=^((pxGenericDB^)["PlayerSettings/Player_"+iHQ.ToString()+"/Restrictions/Base"]);
+			var ^CPropDB.CNode pxNodeBase=pxPlayerBaseNode;
 			pxPlayer^.SetGfxPrefix(pxNodeBase^.GetValueS("GfxPrefix",""));
 			//KLog.LogWarn("CHP","GfxPrefix:"+iOwner.ToString()+" "+pxNodeBase^.GetValueS("GfxPrefix",""));
 			//aiTeams[i]=iTeam;
@@ -781,7 +778,7 @@ class CServerApp inherit IServerApp
 			if(pxPlayerTTDef!=null)then
 				CMirageSrvMgr.Get().HardcodeTTFilters(sLNFHCTTF, i, pxPlayerTTDef);
 			endif;
-			var ^CPropDB.CNode pxTTDef=^((pxGenericDB^)["PlayerSettings/Player_"+iHQ.ToString()+"/Restrictions/TTDef"]);
+			var ^CPropDB.CNode pxTTDef=pxRestrictionsNode^.Get("TTDef");
 			if(pxTTDef!=null)then
 //				var int iSEASCarrierFix=0;
 				var ^CTechTreeDef pxPlayerTTDef=^(pxPlayer^.GetPlayerTechTreeDef());
@@ -802,7 +799,7 @@ class CServerApp inherit IServerApp
 			// set the dipl-stuff for singleplayer and CUSTOM map mode
 			if(!bMultiplayer||CMirageSrvMgr.Get().CheckCustomMap(sLevelName,"Diplomacy/UseRelations"))then
 				var ^CDiplomacySrvMgr pxDiplMgr=^(CSrvWrap.GetDiplomacyMgr());
-				var ^CPropDB.CNode pxDiplNode=pxGenericDB^.FindNode("PlayerSettings/Player_"+iHQ.ToString()+"/Diplomacy",false);
+				var ^CPropDB.CNode pxDiplNode=pxPlayerNode^.FindNode("Diplomacy",false);
 				if(pxDiplNode!=null)then
 					var ^CBasePlayer pxBasePlayer=CBasePlayer.GetPlayer(iHQ);
 					var string sVal=pxDiplNode^.Value();
@@ -823,11 +820,11 @@ class CServerApp inherit IServerApp
 			var ^CPropDB pxUserProfile=^(CSrvWrap.GetCurUserProfile()^.GetPropDB());
 			var int iCurDifficulty=(pxUserProfile^)["Multiplayer/Difficulty"].ValueI();
 			//KLog.LogSpam("ParaworldFan","ServerApp: CreatePlayers() iCurDifficulty=="+iCurDifficulty.ToString());
-			if(iCurDifficulty!=(pxGenericDB^)["Base/Difficulty"].ValueI())then
-				(pxGenericDB^)["Base"].SetValue("Difficulty",iCurDifficulty);
+			if(iCurDifficulty!=pxBaseNode^.GetValueI("Difficulty"))then
+				pxBaseNode^.SetValue("Difficulty",iCurDifficulty);
 			endif;
-		elseif(pxLevelInfo^.IsMultiplayer()&&(pxGenericDB^)["Base/Difficulty"].ValueI()!=1)then
-			(pxGenericDB^)["Base"].SetValue("Difficulty",1);
+		elseif(pxLevelInfo^.IsMultiplayer()&&pxBaseNode^.GetValueI("Difficulty")!=1)then
+			pxBaseNode^.SetValue("Difficulty",1);
 		endif;
 		//
 		
@@ -888,7 +885,7 @@ class CServerApp inherit IServerApp
 				return true;
 			endif;
 		endif;
-		var ^CPropDB.CNode pxBaseNode=^((pxLevelInfo^.GetGenericData())["Base"]);
+		pxBaseNode=^((pxLevelInfo^.GetGenericData())["Base"]);
 		var string sStartTime=pxBaseNode^.GetValueS("StartTime","12:0");
 		var array string asTime;
 		sStartTime.Split(asTime,":",false);

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/settings/custom_maps/custom_level_data.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/settings/custom_maps/custom_level_data.txt
@@ -903,7 +903,7 @@ Root {
 	}
 	Single_16 {
 		random_hq = '0'
-		num_slots = '7'
+		num_slots = '8'
 		#NAME_0 = '_PN_SP16_PLAYER'
 		#NAME_1 = '_PN_SP02_DRUID'
 		#NAME_2 = '_PN_SP03_TRADER'
@@ -1117,6 +1117,7 @@ Root {
 		#COLOR_7 = '4'
 	}
 	BfPW_-_Holy_City_[CUSTOM] {
+		num_slots = '8'
 		TYPE_0 = 'ai_Dodo'
 		TYPE_1 = 'ai_Dodo'
 		TYPE_2 = 'ai_Dodo'


### PR DESCRIPTION
* Fixed issue where PlayerSlot AIBehavior Type were always set to "invalid" forcefully by internalscripts if the SlotID (int) of the current PlayerSlot was >than "num_players" internal variable of CLevelIfno Source code class;
* As result, also solved issue, when the hidden players werent detected in game as an AIPlayers by CLevelInfo.CPlayerSlot function IsAIPlayer(), which was caused by the same reason;
* ServerApp CPropDB Data extraction remanufactured;
* Minor fixes of configs in custom_level_data.txt;
* Custom map config parameters are cleaned up and updated to fit the new updated system. Also fixed some Team bugs;