### PR TITLE
Node System Custom Map UI system overlap fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -12,6 +12,7 @@ General:
  - Fixed incorrect description of Anti-Pause Mirage Server Option in Russian Localization
  - Added player handicap(HP) option for Custom map control options
  - Custom map system parameters customization expanded. Player parameters are from now on can be applied only to exact Player
+ - Predefined map server settings Node have been integrated into new Custom map UI system
  
 Maps:
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/misc/MirageSrvMgr.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/misc/MirageSrvMgr.usl
@@ -718,6 +718,10 @@ class CMirageSrvMgr
 				pxExternalUnpause=^(pxCSNode^.AddValue("ExternalUnpause",iExternalUnpause));
 			else
 				iExternalUnpause=pxCSNode^.GetValueI("ExternalUnpause");
+				if(pxLevelInfo^.IsMultiplayer()&&(iExternalUnpause!=pxGame^.GetAttribInt("ExternalUnpause")))then
+					iExternalUnpause=pxGame^.GetAttribInt("ExternalUnpause");
+					pxCSNode^.SetValue("ExternalUnpause",iExternalUnpause);
+				endif;
 				m_bExternalUnpause=iExternalUnpause==1;
 				m_bExternalUnpauseChecked=true;
 			endif;
@@ -757,6 +761,10 @@ class CMirageSrvMgr
 				pxPauseLimit=^(pxCSNode^.AddValue("PauseLimit",m_iPauseLimit));
 			else
 				m_iPauseLimit=pxCSNode^.GetValueI("PauseLimit");
+				if(pxLevelInfo^.IsMultiplayer()&&(m_iPauseLimit!=pxGame^.GetAttribInt("PauseLimit")))then
+					m_iPauseLimit=pxGame^.GetAttribInt("PauseLimit");
+					pxCSNode^.SetValue("PauseLimit",m_iPauseLimit);
+				endif;
 				m_bPauseLimitChecked=true;
 			endif;
 			return m_iPauseLimit;
@@ -809,6 +817,10 @@ class CMirageSrvMgr
 				pxUseSupply=^(pxCSNode^.AddValue("UseSupply",iUseSupply));
 			else
 				iUseSupply=pxCSNode^.GetValueI("UseSupply");
+				if(pxLevelInfo^.IsMultiplayer()&&(iUseSupply!=pxGame^.GetAttribInt("UseSupply")))then
+					iUseSupply=pxGame^.GetAttribInt("UseSupply");
+					pxCSNode^.SetValue("UseSupply",iUseSupply);
+				endif;
 				m_bUseSupply=iUseSupply==1;
 				m_bUseSupplyChecked=true;
 			endif;
@@ -849,6 +861,10 @@ class CMirageSrvMgr
 				pxShowResourcesInFOW=^(pxCSNode^.AddValue("ShowResourcesInFOW",iShowResourcesInFOW));
 			else
 				iShowResourcesInFOW=pxCSNode^.GetValueI("ShowResourcesInFOW");
+				if(pxLevelInfo^.IsMultiplayer()&&(iShowResourcesInFOW!=pxGame^.GetAttribInt("ShowResourcesInFOW")))then
+					iShowResourcesInFOW=pxGame^.GetAttribInt("ShowResourcesInFOW");
+					pxCSNode^.SetValue("ShowResourcesInFOW",iShowResourcesInFOW);
+				endif;
 				m_bShowResourcesInFOW=iShowResourcesInFOW==1;
 				m_bShowResourcesInFOWChecked=true;
 			endif;
@@ -889,6 +905,10 @@ class CMirageSrvMgr
 				pxAnimalsVisInFOW=^(pxCSNode^.AddValue("AnimalsVisInFOW",iAnimalsVisInFOW));
 			else
 				iAnimalsVisInFOW=pxCSNode^.GetValueI("AnimalsVisInFOW");
+				if(pxLevelInfo^.IsMultiplayer()&&(iAnimalsVisInFOW!=pxGame^.GetAttribInt("AnimalsVisInFOW")))then
+					iAnimalsVisInFOW=pxGame^.GetAttribInt("AnimalsVisInFOW");
+					pxCSNode^.SetValue("AnimalsVisInFOW",iAnimalsVisInFOW);
+				endif;
 				m_bAnimalsVisInFOW=iAnimalsVisInFOW==1;
 				m_bAnimalsVisInFOWChecked=true;
 			endif;
@@ -961,6 +981,10 @@ class CMirageSrvMgr
 			pxTotalDefAllowed=^(pxCSNode^.AddValue("TotalDefAllowed",iAllowed));
 		else
 			iAllowed=pxCSNode^.GetValueI("TotalDefAllowed");
+			if(pxLevelInfo^.IsMultiplayer()&&(iAllowed!=pxGame^.GetAttribInt("PerfectArmor")))then
+				iAllowed=pxGame^.GetAttribInt("PerfectArmor");
+				pxCSNode^.SetValue("TotalDefAllowed",iAllowed);
+			endif;
 			if(iAllowed==1)then
 				m_fMaxDef=1.0f;
 			endif;
@@ -998,6 +1022,10 @@ class CMirageSrvMgr
 			pxCorpseDmgAllowed=^(pxCSNode^.AddValue("CorpseDmgAllowed",iAllowed));
 		else
 			iAllowed=pxCSNode^.GetValueI("CorpseDmgAllowed");
+			if(pxLevelInfo^.IsMultiplayer()&&(iAllowed!=pxGame^.GetAttribInt("CorpseDamage")))then
+				iAllowed=pxGame^.GetAttribInt("CorpseDamage");
+				pxCSNode^.SetValue("CorpseDmgAllowed",iAllowed);
+			endif;
 			CResource.ms_bCORPSEDMG=iAllowed==1;
 		endif;
 		return true;
@@ -1043,6 +1071,10 @@ class CMirageSrvMgr
 				pxDiploLocked=^(pxCSNode^.AddValue("DiploLocked",iDiploLocked));
 			else
 				iDiploLocked=pxCSNode^.GetValueI("DiploLocked");
+				if(pxLevelInfo^.IsMultiplayer()&&(iDiploLocked!=pxGame^.GetAttribInt("DiplomacyLocked")))then
+					iDiploLocked=pxGame^.GetAttribInt("DiplomacyLocked");
+					pxCSNode^.SetValue("DiploLocked",iDiploLocked);
+				endif;
 				m_bDiploLocked=iDiploLocked==1;
 				m_bDiploLockedChecked=true;
 			endif;
@@ -1119,6 +1151,10 @@ class CMirageSrvMgr
 				pxHeroPool=^(pxCSNode^.AddValue("HeroPool",iHeroPool));
 			else
 				iHeroPool=pxCSNode^.GetValueI("HeroPool");
+				if(pxLevelInfo^.IsMultiplayer()&&(iHeroPool!=pxGame^.GetAttribInt("HeroPool")))then
+					iHeroPool=pxGame^.GetAttribInt("HeroPool");
+					pxCSNode^.SetValue("HeroPool",iHeroPool);
+				endif;
 				m_bHeroPool=iHeroPool==1;
 				m_bHeroPoolChecked=true;
 			endif;
@@ -1159,6 +1195,10 @@ class CMirageSrvMgr
 				pxResourcesUnlimited=^(pxCSNode^.AddValue("ResourcesUnlimited",iResourcesUnlimited));
 			else
 				iResourcesUnlimited=pxCSNode^.GetValueI("ResourcesUnlimited");
+				if(pxLevelInfo^.IsMultiplayer()&&(iResourcesUnlimited!=pxGame^.GetAttribInt("ResourcesUnlimited")))then
+					iResourcesUnlimited=pxGame^.GetAttribInt("ResourcesUnlimited");
+					pxCSNode^.SetValue("ResourcesUnlimited",iResourcesUnlimited);
+				endif;
 				m_bResourcesUnlimited=iResourcesUnlimited==1;
 				m_bResourcesUnlimitedChecked=true;
 			endif;
@@ -1199,6 +1239,10 @@ class CMirageSrvMgr
 				pxBuildingCancellation=^(pxCSNode^.AddValue("BuildingCancellation",iBuildingCancellation));
 			else
 				iBuildingCancellation=pxCSNode^.GetValueI("BuildingCancellation");
+				if(pxLevelInfo^.IsMultiplayer()&&(iBuildingCancellation!=pxGame^.GetAttribInt("BuildingCancellation")))then
+					iBuildingCancellation=pxGame^.GetAttribInt("BuildingCancellation");
+					pxCSNode^.SetValue("BuildingCancellation",iBuildingCancellation);
+				endif;
 				m_bBuildingCancellation=iBuildingCancellation==1;
 				m_bBuildingCancellationChecked=true;
 			endif;
@@ -1239,6 +1283,10 @@ class CMirageSrvMgr
 				pxNoHQTimer=^(pxCSNode^.AddValue("NoHQTimer",ms_fHQTimer));
 			else
 				ms_fHQTimer=pxCSNode^.GetValueR("NoHQTimer");
+				if(pxLevelInfo^.IsMultiplayer()&&(ms_fHQTimer!=pxGame^.GetAttrib("HQTimer").ToReal()))then
+					ms_fHQTimer=pxGame^.GetAttrib("HQTimer").ToReal();
+					pxCSNode^.SetValue("NoHQTimer",ms_fHQTimer);
+				endif;
 				m_bNoHQTimer=ms_fHQTimer<=-1.0f;
 				m_bNoHQTimerChecked=true;
 			endif;
@@ -1279,6 +1327,10 @@ class CMirageSrvMgr
 				pxWarpInvisible=^(pxCSNode^.AddValue("WarpInvisible",iWarpInvisible));
 			else
 				iWarpInvisible=pxCSNode^.GetValueI("WarpInvisible");
+				if(pxLevelInfo^.IsMultiplayer()&&(iWarpInvisible!=pxGame^.GetAttribInt("WarpInvisible")))then
+					iWarpInvisible=pxGame^.GetAttribInt("WarpInvisible");
+					pxCSNode^.SetValue("WarpInvisible",iWarpInvisible);
+				endif;
 				m_bWarpInvisible=iWarpInvisible==1;
 				m_bWarpInvisibleChecked=true;
 			endif;
@@ -1319,6 +1371,10 @@ class CMirageSrvMgr
 				pxPortals=^(pxCSNode^.AddValue("Portals",iPortals));
 			else
 				iPortals=pxCSNode^.GetValueI("Portals");
+				if(pxLevelInfo^.IsMultiplayer()&&(iPortals!=pxGame^.GetAttribInt("Portals")))then
+					iPortals=pxGame^.GetAttribInt("Portals");
+					pxCSNode^.SetValue("Portals",iPortals);
+				endif;
 				m_bPortals=iPortals==1;
 				m_bPortalsChecked=true;
 			endif;
@@ -1364,6 +1420,10 @@ class CMirageSrvMgr
 				pxNestRespawn=^(pxCSNode^.AddValue("NestRespawn",iNestRespawn));
 			else
 				iNestRespawn=pxCSNode^.GetValueI("NestRespawn");
+				if(pxLevelInfo^.IsMultiplayer()&&(iNestRespawn!=pxGame^.GetAttribInt("NestRespawn")))then
+					iNestRespawn=pxGame^.GetAttribInt("NestRespawn");
+					pxCSNode^.SetValue("NestRespawn",iNestRespawn);
+				endif;
 				m_bNestRespawn=iNestRespawn==1;
 				m_bNestRespawnChecked=true;
 			endif;
@@ -1408,6 +1468,10 @@ class CMirageSrvMgr
 				pxTransportHealing=^(pxCSNode^.AddValue("TransportHealing",iTransportHealing));
 			else
 				iTransportHealing=pxCSNode^.GetValueI("TransportHealing");
+				if(pxLevelInfo^.IsMultiplayer()&&(iTransportHealing!=pxGame^.GetAttribInt("TransportHealing")))then
+					iTransportHealing=pxGame^.GetAttribInt("TransportHealing");
+					pxCSNode^.SetValue("TransportHealing",iTransportHealing);
+				endif;
 				m_bTransportHealing=iTransportHealing>0;
 				m_bTransportHealingChecked=true;
 			endif;
@@ -1453,6 +1517,10 @@ class CMirageSrvMgr
 				pxManaEnabled=^(pxCSNode^.AddValue("ManaEnabled",iManaEnabled));
 			else
 				iManaEnabled=pxCSNode^.GetValueI("ManaEnabled");
+				if(pxLevelInfo^.IsMultiplayer()&&(iManaEnabled!=pxGame^.GetAttribInt("ManaEnabled")))then
+					iManaEnabled=pxGame^.GetAttribInt("ManaEnabled");
+					pxCSNode^.SetValue("ManaEnabled",iManaEnabled);
+				endif;
 				m_bManaEnabled=iManaEnabled==1;
 				m_bManaEnabledChecked=true;
 			endif;
@@ -1493,6 +1561,10 @@ class CMirageSrvMgr
 				pxUnitResources=^(pxCSNode^.AddValue("UnitResources",iUnitResources));
 			else
 				iUnitResources=pxCSNode^.GetValueI("UnitResources");
+				if(pxLevelInfo^.IsMultiplayer()&&(iUnitResources!=pxGame^.GetAttribInt("UnitResources")))then
+					iUnitResources=pxGame^.GetAttribInt("UnitResources");
+					pxCSNode^.SetValue("UnitResources",iUnitResources);
+				endif;
 				m_bUnitResources=iUnitResources==1;
 				m_bUnitResourcesChecked=true;
 			endif;
@@ -1533,6 +1605,10 @@ class CMirageSrvMgr
 				pxBuildingBurndown=^(pxCSNode^.AddValue("BuildingBurndown",iBuildingBurndown));
 			else
 				iBuildingBurndown=pxCSNode^.GetValueI("BuildingBurndown");
+				if(pxLevelInfo^.IsMultiplayer()&&(iBuildingBurndown!=pxGame^.GetAttribInt("BuildingBurndown")))then
+					iBuildingBurndown=pxGame^.GetAttribInt("BuildingBurndown");
+					pxCSNode^.SetValue("BuildingBurndown",iBuildingBurndown);
+				endif;
 				m_bBuildingBurndown=iBuildingBurndown==1;
 				m_bBuildingBurndownChecked=true;
 			endif;
@@ -1573,6 +1649,10 @@ class CMirageSrvMgr
 				pxUseFinishingMoves=^(pxCSNode^.AddValue("UseFM",iUseFinishingMoves));
 			else
 				iUseFinishingMoves=pxCSNode^.GetValueI("UseFM");
+				if(pxLevelInfo^.IsMultiplayer()&&(iUseFinishingMoves!=pxGame^.GetAttribInt("UseFM")))then
+					iUseFinishingMoves=pxGame^.GetAttribInt("UseFM");
+					pxCSNode^.SetValue("UseFM",iUseFinishingMoves);
+				endif;
 				m_bUseFinishingMoves=iUseFinishingMoves==1;
 				m_bUseFinishingMovesChecked=true;
 			endif;
@@ -1616,6 +1696,10 @@ class CMirageSrvMgr
 				pxFreeSpecials=^(pxCSNode^.AddValue("FreeSpecials",iFreeSpecials));
 			else
 				iFreeSpecials=pxCSNode^.GetValueI("FreeSpecials");
+				if(pxLevelInfo^.IsMultiplayer()&&(iFreeSpecials!=pxGame^.GetAttribInt("FreeSpecials")))then
+					iFreeSpecials=pxGame^.GetAttribInt("FreeSpecials");
+					pxCSNode^.SetValue("FreeSpecials",iFreeSpecials);
+				endif;
 				m_bFreeSpecials=iFreeSpecials==1;
 				m_bFreeSpecialsChecked=true;
 			endif;
@@ -1654,6 +1738,10 @@ class CMirageSrvMgr
 				pxBonusSkulls=^(pxCSNode^.AddValue("BonusSkulls",iBonusSkulls));
 			else
 				iBonusSkulls=pxCSNode^.GetValueI("BonusSkulls");
+				if(pxLevelInfo^.IsMultiplayer()&&(iBonusSkulls!=pxGame^.GetAttribInt("BonusSkulls")))then
+					iBonusSkulls=pxGame^.GetAttribInt("BonusSkulls");
+					pxCSNode^.SetValue("BonusSkulls",iBonusSkulls);
+				endif;
 				m_bBonusSkulls=iBonusSkulls==1;
 				m_bBonusSkullsChecked=true;
 			endif;
@@ -1704,6 +1792,16 @@ class CMirageSrvMgr
 				m_bEpochSixChecked=true;
 			else
 				iEpochSix=pxCSNode^.GetValueI("EpochSix");
+				var int iMaxEpoch=pxGame^.GetAttribInt("MaxEpoch");
+				if(pxLevelInfo^.IsMultiplayer()&&(iEpochSix!=iMaxEpoch))then
+					if(iMaxEpoch>=6)then
+						iEpochSix=1;
+					else
+						iEpochSix=0;
+					endif;
+					pxCSNode^.SetValue("EpochSix",iEpochSix);
+					pxCSNode^.SetValue("MaxEpoch",iMaxEpoch);
+				endif;
 				m_bEpochSix=iEpochSix==1;
 				m_bEpochSixChecked=true;
 			endif;
@@ -1754,6 +1852,10 @@ class CMirageSrvMgr
 				pxNoWGTimer=^(pxCSNode^.AddValue("NoWGTimer",ms_fWGTimer));
 			else
 				ms_fWGTimer=pxCSNode^.GetValueR("NoWGTimer");
+				if(pxLevelInfo^.IsMultiplayer()&&(ms_fWGTimer!=pxGame^.GetAttrib("WarpGateTimer").ToReal()))then
+					ms_fWGTimer=pxGame^.GetAttrib("WarpGateTimer").ToReal();
+					pxCSNode^.SetValue("NoWGTimer",ms_fWGTimer);
+				endif;
 				m_bNoWGTimer=ms_fWGTimer<=0.0f;
 				m_bNoWGTimerChecked=true;
 			endif;
@@ -1792,6 +1894,10 @@ class CMirageSrvMgr
 				pxTitanSlots=^(pxCSNode^.AddValue("TitanSlots",iTitanSlots));
 			else
 				iTitanSlots=pxCSNode^.GetValueI("TitanSlots");
+				if(pxLevelInfo^.IsMultiplayer()&&(iTitanSlots!=pxGame^.GetAttribInt("TitanSlots")))then
+					iTitanSlots=pxGame^.GetAttribInt("TitanSlots");
+					pxCSNode^.SetValue("TitanSlots",iTitanSlots);
+				endif;
 				m_bTitanSlots=iTitanSlots==1;
 				m_bTitanSlotsChecked=true;
 			endif;
@@ -1830,6 +1936,10 @@ class CMirageSrvMgr
 				pxHeroGratis=^(pxCSNode^.AddValue("HeroGratis",iHeroGratis));
 			else
 				iHeroGratis=pxCSNode^.GetValueI("HeroGratis");
+				if(pxLevelInfo^.IsMultiplayer()&&(iHeroGratis!=pxGame^.GetAttribInt("HeroGratis")))then
+					iHeroGratis=pxGame^.GetAttribInt("HeroGratis");
+					pxCSNode^.SetValue("HeroGratis",iHeroGratis);
+				endif;
 				m_bHeroGratis=iHeroGratis==1;
 				m_bHeroGratisChecked=true;
 			endif;
@@ -1868,6 +1978,10 @@ class CMirageSrvMgr
 				pxFlyingEnabled=^(pxCSNode^.AddValue("FlyingEnabled",iFlyingEnabled));
 			else
 				iFlyingEnabled=pxCSNode^.GetValueI("FlyingEnabled");
+				if(pxLevelInfo^.IsMultiplayer()&&(iFlyingEnabled!=pxGame^.GetAttribInt("FlyingEnabled")))then
+					iFlyingEnabled=pxGame^.GetAttribInt("FlyingEnabled");
+					pxCSNode^.SetValue("FlyingEnabled",iFlyingEnabled);
+				endif;
 				m_bFlyingEnabled=iFlyingEnabled==1;
 				m_bFlyingEnabledChecked=true;
 			endif;
@@ -1902,6 +2016,10 @@ class CMirageSrvMgr
 				pxDwnLvlSwitch=^(pxCSNode^.AddValue("DwnLvlSwitch",m_iDwnLvlSwitch));
 			else
 				m_iDwnLvlSwitch=pxCSNode^.GetValueI("DwnLvlSwitch");
+				if(pxLevelInfo^.IsMultiplayer()&&(m_iDwnLvlSwitch!=pxGame^.GetAttribInt("DwnLvlSwitch")))then
+					m_iDwnLvlSwitch=pxGame^.GetAttribInt("DwnLvlSwitch");
+					pxCSNode^.SetValue("DwnLvlSwitch",m_iDwnLvlSwitch);
+				endif;
 				m_bDwnLvlSwitchChecked=true;
 			endif;
 			return m_iDwnLvlSwitch;
@@ -1939,6 +2057,10 @@ class CMirageSrvMgr
 				pxTreasureSharing=^(pxCSNode^.AddValue("TreasureSharing",iTreasureSharing));
 			else
 				iTreasureSharing=pxCSNode^.GetValueI("TreasureSharing");
+				if(pxLevelInfo^.IsMultiplayer()&&(iTreasureSharing!=pxGame^.GetAttribInt("TreasureSharing")))then
+					iTreasureSharing=pxGame^.GetAttribInt("TreasureSharing");
+					pxCSNode^.SetValue("TreasureSharing",iTreasureSharing);
+				endif;
 				m_bTreasureSharing=iTreasureSharing==1;
 				m_bTreasureSharingChecked=true;
 			endif;
@@ -1977,6 +2099,10 @@ class CMirageSrvMgr
 				pxFruitsRemovement=^(pxCSNode^.AddValue("FruitsRemovement",iFruitsRemovement));
 			else
 				iFruitsRemovement=pxCSNode^.GetValueI("FruitsRemovement");
+				if(pxLevelInfo^.IsMultiplayer()&&(iFruitsRemovement!=pxGame^.GetAttribInt("FruitsRemovement")))then
+					iFruitsRemovement=pxGame^.GetAttribInt("FruitsRemovement");
+					pxCSNode^.SetValue("FruitsRemovement",iFruitsRemovement);
+				endif;
 				m_bFruitsRemovement=iFruitsRemovement==1;
 				m_bFruitsRemovementChecked=true;
 			endif;
@@ -2015,6 +2141,10 @@ class CMirageSrvMgr
 				pxEarlyTransport=^(pxCSNode^.AddValue("EarlyTransport",iEarlyTransport));
 			else
 				iEarlyTransport=pxCSNode^.GetValueI("EarlyTransport");
+				if(pxLevelInfo^.IsMultiplayer()&&(iEarlyTransport!=pxGame^.GetAttribInt("EarlyTransport")))then
+					iEarlyTransport=pxGame^.GetAttribInt("EarlyTransport");
+					pxCSNode^.SetValue("EarlyTransport",iEarlyTransport);
+				endif;
 				m_bEarlyTransport=iEarlyTransport==1;
 				m_bEarlyTransportChecked=true;
 			endif;
@@ -2114,6 +2244,46 @@ class CMirageSrvMgr
 				m_bBloodBrothers=pxCSNode^.GetValueI("BloodBrothers")==1;
 				m_bSoulKeepers=pxCSNode^.GetValueI("SoulKeepers")==1&&(m_bRandomRoles||m_iDefenders>0);
 				m_bPopulationBonus=pxCSNode^.GetValueI("PopulationBonus")==1;
+				if(pxLevelInfo^.IsMultiplayer()&&(iPhantomMode!=pxGame^.GetAttribInt("PhantomMode")))then
+					iPhantomMode=pxGame^.GetAttribInt("PhantomMode");
+					pxCSNode^.SetValue("PhantomMode",iPhantomMode);
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(pxCSNode^.GetValueI("RandomRoles")!=pxGame^.GetAttribInt("RandomRoles")))then
+					m_bRandomRoles=pxGame^.GetAttribInt("RandomRoles")==1;
+					pxCSNode^.SetValue("RandomRoles",pxGame^.GetAttribInt("RandomRoles"));
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(pxCSNode^.GetValueI("SeerPlayer")!=pxGame^.GetAttribInt("SeerPlayer")))then
+					m_bSeerPlayer=pxGame^.GetAttribInt("SeerPlayer")==1&&m_bRandomRoles;
+					pxCSNode^.SetValue("SeerPlayer",pxGame^.GetAttribInt("SeerPlayer"));
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(m_iConquerors!=pxGame^.GetAttribInt("ConquerorNumber")))then
+					m_iConquerors=pxGame^.GetAttribInt("ConquerorNumber");
+					pxCSNode^.SetValue("ConquerorNumber",m_iConquerors);
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(m_iPaladins!=pxGame^.GetAttribInt("PaladinNumber")))then
+					m_iPaladins=pxGame^.GetAttribInt("PaladinNumber");
+					pxCSNode^.SetValue("PaladinNumber",m_iPaladins);
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(m_iDefenders!=pxGame^.GetAttribInt("DefenderNumber")))then
+					m_iDefenders=pxGame^.GetAttribInt("DefenderNumber");
+					pxCSNode^.SetValue("DefenderNumber",m_iDefenders);
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(pxGame^.GetAttribInt("Revelation")!=pxGame^.GetAttribInt("Revelation")))then
+					m_bRevelation=pxGame^.GetAttribInt("Revelation")==1&&(m_bRandomRoles||m_iConquerors>1);
+					pxCSNode^.SetValue("Revelation",pxGame^.GetAttribInt("Revelation"));
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(pxGame^.GetAttribInt("BloodBrothers")!=pxGame^.GetAttribInt("BloodBrothers")))then
+					m_bBloodBrothers=pxGame^.GetAttribInt("BloodBrothers")==1;
+					pxCSNode^.SetValue("BloodBrothers",pxGame^.GetAttribInt("BloodBrothers"));
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(pxGame^.GetAttribInt("SoulKeepers")!=pxGame^.GetAttribInt("SoulKeepers")))then
+					m_bSoulKeepers=pxGame^.GetAttribInt("SoulKeepers")==1&&(m_bRandomRoles||m_iDefenders>0);
+					pxCSNode^.SetValue("SoulKeepers",pxGame^.GetAttribInt("SoulKeepers"));
+				endif;
+				if(pxLevelInfo^.IsMultiplayer()&&(pxGame^.GetAttribInt("PopulationBonu")!=pxGame^.GetAttribInt("PopulationBonu")))then
+					m_bPopulationBonus=pxGame^.GetAttribInt("PopulationBonus")==1;
+					pxCSNode^.SetValue("PopulationBonu",pxGame^.GetAttribInt("PopulationBonu"));
+				endif;
 				m_bPhantomMode=iPhantomMode==1;
 				m_bPhantomModeChecked=true;
 			endif;
@@ -2197,6 +2367,10 @@ class CMirageSrvMgr
 				pxSandGlass=^(pxCSNode^.AddValue("SandGlass",m_iSandGlass));
 			else
 				m_iSandGlass=pxCSNode^.GetValueI("SandGlass");
+				if(pxLevelInfo^.IsMultiplayer()&&(m_iSandGlass!=pxGame^.GetAttribInt("SandGlass")))then
+					m_iSandGlass=pxGame^.GetAttribInt("SandGlass");
+					pxCSNode^.SetValue("SandGlass",m_iSandGlass);
+				endif;
 				m_bSandGlass=m_iSandGlass>0;
 				m_bSandGlassChecked=true;
 			endif;
@@ -2238,6 +2412,11 @@ class CMirageSrvMgr
 				pxDominationUpDownTimer=^(pxCSNode^.AddValue("DominationUpDownTimer",ms_fDFTimer));
 			else
 				ms_fDFTimer=pxCSNode^.GetValueR("DominationUpDownTimer");
+				var real fDfTimer=Math.Clamp(pxGame^.GetAttrib("DominationUpDownTimer").ToReal(),1.0,30.0);
+				if(pxLevelInfo^.IsMultiplayer()&&(ms_fDFTimer!=fDfTimer))then
+					ms_fDFTimer=fDfTimer;
+					pxCSNode^.SetValue("DominationUpDownTimer",ms_fDFTimer);
+				endif;
 				m_bDominationUpDownTimerChecked=true;
 			endif;
 			return true;
@@ -2275,6 +2454,10 @@ class CMirageSrvMgr
 				pxBldgMaxCapacity=^(pxCSNode^.AddValue("BldgMaxCapacity",iBldgMaxCapacity));
 			else
 				iBldgMaxCapacity=pxCSNode^.GetValueI("BldgMaxCapacity");
+				if(pxLevelInfo^.IsMultiplayer()&&(iBldgMaxCapacity!=pxGame^.GetAttribInt("BldgMaxCapacity")))then
+					iBldgMaxCapacity=pxGame^.GetAttribInt("BldgMaxCapacity");
+					pxCSNode^.SetValue("BldgMaxCapacity",iBldgMaxCapacity);
+				endif;
 				m_bBldgMaxCapacity=iBldgMaxCapacity==1;
 				m_bBldgMaxCapacityChecked=true;
 			endif;
@@ -2313,6 +2496,10 @@ class CMirageSrvMgr
 				pxSpeedUp=^(pxCSNode^.AddValue("SpeedUp",iSpeedUp));
 			else
 				iSpeedUp=pxCSNode^.GetValueI("SpeedUp");
+				if(pxLevelInfo^.IsMultiplayer()&&(iSpeedUp!=pxGame^.GetAttribInt("SpeedUp")))then
+					iSpeedUp=pxGame^.GetAttribInt("SpeedUp");
+					pxCSNode^.SetValue("SpeedUp",iSpeedUp);
+				endif;
 				m_bSpeedUp=iSpeedUp==1;
 				m_bSpeedUpChecked=true;
 			endif;
@@ -2390,6 +2577,10 @@ class CMirageSrvMgr
 				pxAllowThrow=^(pxCSNode^.AddValue("AllowThrow",iAllowThrow));
 			else
 				iAllowThrow=pxCSNode^.GetValueI("AllowThrow");
+				if(pxLevelInfo^.IsMultiplayer()&&(iAllowThrow!=pxGame^.GetAttribInt("AllowThrow")))then
+					iAllowThrow=pxGame^.GetAttribInt("AllowThrow");
+					pxCSNode^.SetValue("AllowThrow",iAllowThrow);
+				endif;
 				m_bAllowThrow=iAllowThrow==1;
 				m_bAllowThrowChecked=true;
 			endif;
@@ -2428,6 +2619,10 @@ class CMirageSrvMgr
 				pxUseOldSpirits=^(pxCSNode^.AddValue("UseOldSpirits",iUseOldSpirits));
 			else
 				iUseOldSpirits=pxCSNode^.GetValueI("UseOldSpirits");
+				if(pxLevelInfo^.IsMultiplayer()&&(iUseOldSpirits!=pxGame^.GetAttribInt("UseOldSpirits")))then
+					iUseOldSpirits=pxGame^.GetAttribInt("UseOldSpirits");
+					pxCSNode^.SetValue("UseOldSpirits",iUseOldSpirits);
+				endif;
 				m_bUseOldSpirits=iUseOldSpirits==1;
 				m_bUseOldSpiritsChecked=true;
 			endif;
@@ -2466,6 +2661,10 @@ class CMirageSrvMgr
 				pxGlobalReanim=^(pxCSNode^.AddValue("GlobalReanim",iGlobalReanim));
 			else
 				iGlobalReanim=pxCSNode^.GetValueI("GlobalReanim");
+				if(pxLevelInfo^.IsMultiplayer()&&(iGlobalReanim!=pxGame^.GetAttribInt("GlobalReanim")))then
+					iGlobalReanim=pxGame^.GetAttribInt("GlobalReanim");
+					pxCSNode^.SetValue("GlobalReanim",iGlobalReanim);
+				endif;
 				m_bGlobalReanim=iGlobalReanim==1;
 				m_bGlobalReanimChecked=true;
 			endif;
@@ -2543,6 +2742,10 @@ class CMirageSrvMgr
 				pxDisableBurning=^(pxCSNode^.AddValue("DisableBurning",iDisableBurning));
 			else
 				iDisableBurning=pxCSNode^.GetValueI("DisableBurning");
+				if(pxLevelInfo^.IsMultiplayer()&&(iDisableBurning!=pxGame^.GetAttribInt("DisableBurning")))then
+					iDisableBurning=pxGame^.GetAttribInt("DisableBurning");
+					pxCSNode^.SetValue("DisableBurning",iDisableBurning);
+				endif;
 				m_bDisableBurning=iDisableBurning==1;
 				m_bDisableBurningChecked=true;
 			endif;
@@ -2581,6 +2784,10 @@ class CMirageSrvMgr
 				pxDisableArtifactRelease=^(pxCSNode^.AddValue("DisableArtifactRelease",iDisableArtifactRelease));
 			else
 				iDisableArtifactRelease=pxCSNode^.GetValueI("DisableArtifactRelease");
+				if(pxLevelInfo^.IsMultiplayer()&&(iDisableArtifactRelease!=pxGame^.GetAttribInt("DisableArtifactRelease")))then
+					iDisableArtifactRelease=pxGame^.GetAttribInt("DisableArtifactRelease");
+					pxCSNode^.SetValue("DisableArtifactRelease",iDisableArtifactRelease);
+				endif;
 				m_bDisableArtifactRelease=iDisableArtifactRelease==1;
 				m_bDisableArtifactReleaseChecked=true;
 			endif;
@@ -2658,6 +2865,10 @@ class CMirageSrvMgr
 				pxExcludeBuildUp=^(pxCSNode^.AddValue("ExcludeBuildUp",iExcludeBuildUp));
 			else
 				iExcludeBuildUp=pxCSNode^.GetValueI("ExcludeBuildUp");
+				if(pxLevelInfo^.IsMultiplayer()&&(iExcludeBuildUp!=pxGame^.GetAttribInt("ExcludeBuildUp")))then
+					iExcludeBuildUp=pxGame^.GetAttribInt("ExcludeBuildUp");
+					pxCSNode^.SetValue("ExcludeBuildUp",iExcludeBuildUp);
+				endif;
 				m_bExcludeBuildUp=iExcludeBuildUp==1;
 				m_bExcludeBuildUpChecked=true;
 			endif;
@@ -2696,6 +2907,10 @@ class CMirageSrvMgr
 				pxAttackInFOW=^(pxCSNode^.AddValue("AttackInFOW",iAttackInFOW));
 			else
 				iAttackInFOW=pxCSNode^.GetValueI("AttackInFOW");
+				if(pxLevelInfo^.IsMultiplayer()&&(iAttackInFOW!=pxGame^.GetAttribInt("AttackInFOW")))then
+					iAttackInFOW=pxGame^.GetAttribInt("AttackInFOW");
+					pxCSNode^.SetValue("AttackInFOW",iAttackInFOW);
+				endif;
 				m_bAttackInFOW=iAttackInFOW==1;
 				m_bAttackInFOWChecked=true;
 			endif;
@@ -2734,6 +2949,10 @@ class CMirageSrvMgr
 				pxOldDisembark=^(pxCSNode^.AddValue("OldDisembark",iOldDisembark));
 			else
 				iOldDisembark=pxCSNode^.GetValueI("OldDisembark");
+				if(pxLevelInfo^.IsMultiplayer()&&(iOldDisembark!=pxGame^.GetAttribInt("OldDisembark")))then
+					iOldDisembark=pxGame^.GetAttribInt("OldDisembark");
+					pxCSNode^.SetValue("OldDisembark",iOldDisembark);
+				endif;
 				m_bOldDisembark=iOldDisembark==1;
 				m_bOldDisembarkChecked=true;
 			endif;
@@ -2772,6 +2991,10 @@ class CMirageSrvMgr
 				pxAuraSharing=^(pxCSNode^.AddValue("AuraSharing",iAuraSharing));
 			else
 				iAuraSharing=pxCSNode^.GetValueI("AuraSharing");
+				if(pxLevelInfo^.IsMultiplayer()&&(iAuraSharing!=pxGame^.GetAttribInt("AuraSharing")))then
+					iAuraSharing=pxGame^.GetAttribInt("AuraSharing");
+					pxCSNode^.SetValue("AuraSharing",iAuraSharing);
+				endif;
 				m_bAuraSharing=iAuraSharing==1;
 				m_bAuraSharingChecked=true;
 			endif;
@@ -2810,6 +3033,10 @@ class CMirageSrvMgr
 				pxTechtreeSteal=^(pxCSNode^.AddValue("TechtreeSteal",iTechtreeSteal));
 			else
 				iTechtreeSteal=pxCSNode^.GetValueI("TechtreeSteal");
+				if(pxLevelInfo^.IsMultiplayer()&&(iTechtreeSteal!=pxGame^.GetAttribInt("TechtreeSteal")))then
+					iTechtreeSteal=pxGame^.GetAttribInt("TechtreeSteal");
+					pxCSNode^.SetValue("TechtreeSteal",iTechtreeSteal);
+				endif;
 				m_bTechtreeSteal=iTechtreeSteal==1;
 				m_bTechtreeStealChecked=true;
 			endif;
@@ -2848,6 +3075,10 @@ class CMirageSrvMgr
 				pxMultiTribe=^(pxCSNode^.AddValue("MultiTribe",iMultiTribe));
 			else
 				iMultiTribe=pxCSNode^.GetValueI("MultiTribe");
+				if(pxLevelInfo^.IsMultiplayer()&&(iMultiTribe!=pxGame^.GetAttribInt("MultiTribe")))then
+					iMultiTribe=pxGame^.GetAttribInt("MultiTribe");
+					pxCSNode^.SetValue("MultiTribe",iMultiTribe);
+				endif;
 				m_bMultiTribe=iMultiTribe==1;
 				m_bMultiTribeChecked=true;
 			endif;
@@ -2886,6 +3117,10 @@ class CMirageSrvMgr
 				pxDivideSkulls=^(pxCSNode^.AddValue("DivideSkulls",iDivideSkulls));
 			else
 				iDivideSkulls=pxCSNode^.GetValueI("DivideSkulls");
+				if(pxLevelInfo^.IsMultiplayer()&&(iDivideSkulls!=pxGame^.GetAttribInt("DivideSkulls")))then
+					iDivideSkulls=pxGame^.GetAttribInt("DivideSkulls");
+					pxCSNode^.SetValue("DivideSkulls",iDivideSkulls);
+				endif;
 				m_bDivideSkulls=iDivideSkulls==1;
 				m_bDivideSkullsChecked=true;
 			endif;
@@ -2924,6 +3159,10 @@ class CMirageSrvMgr
 				pxObserverChat=^(pxCSNode^.AddValue("ObserverChat",iObserverChat));
 			else
 				iObserverChat=pxCSNode^.GetValueI("ObserverChat");
+				if(pxLevelInfo^.IsMultiplayer()&&(iObserverChat!=pxGame^.GetAttribInt("ObserverChat")))then
+					iObserverChat=pxGame^.GetAttribInt("ObserverChat");
+					pxCSNode^.SetValue("ObserverChat",iObserverChat);
+				endif;
 				m_bObserverChat=iObserverChat==1;
 				m_bObserverChatChecked=true;
 			endif;
@@ -2962,6 +3201,10 @@ class CMirageSrvMgr
 				pxNoHumpWalking=^(pxCSNode^.AddValue("NoHumpWalking",iNoHumpWalking));
 			else
 				iNoHumpWalking=pxCSNode^.GetValueI("NoHumpWalking");
+				if(pxLevelInfo^.IsMultiplayer()&&(iNoHumpWalking!=pxGame^.GetAttribInt("NoHumpWalking")))then
+					iNoHumpWalking=pxGame^.GetAttribInt("NoHumpWalking");
+					pxCSNode^.SetValue("NoHumpWalking",iNoHumpWalking);
+				endif;
 				m_bNoHumpWalking=iNoHumpWalking==1;
 				m_bNoHumpWalkingChecked=true;
 			endif;
@@ -3000,6 +3243,10 @@ class CMirageSrvMgr
 				pxRemoveTitans=^(pxCSNode^.AddValue("RemoveTitans",iRemoveTitans));
 			else
 				iRemoveTitans=pxCSNode^.GetValueI("RemoveTitans");
+				if(pxLevelInfo^.IsMultiplayer()&&(iRemoveTitans!=pxGame^.GetAttribInt("RemoveTitans")))then
+					iRemoveTitans=pxGame^.GetAttribInt("RemoveTitans");
+					pxCSNode^.SetValue("RemoveTitans",iRemoveTitans);
+				endif;
 				m_bRemoveTitans=iRemoveTitans==1;
 				m_bRemoveTitansChecked=true;
 			endif;
@@ -3038,6 +3285,10 @@ class CMirageSrvMgr
 				pxRemoveTrading=^(pxCSNode^.AddValue("RemoveTrading",iRemoveTrading));
 			else
 				iRemoveTrading=pxCSNode^.GetValueI("RemoveTrading");
+				if(pxLevelInfo^.IsMultiplayer()&&(iRemoveTrading!=pxGame^.GetAttribInt("RemoveTrading")))then
+					iRemoveTrading=pxGame^.GetAttribInt("RemoveTrading");
+					pxCSNode^.SetValue("RemoveTrading",iRemoveTrading);
+				endif;
 				m_bRemoveTrading=iRemoveTrading==1;
 				m_bRemoveTradingChecked=true;
 			endif;
@@ -3076,6 +3327,10 @@ class CMirageSrvMgr
 				pxInfantryWar=^(pxCSNode^.AddValue("InfantryWar",iInfantryWar));
 			else
 				iInfantryWar=pxCSNode^.GetValueI("InfantryWar");
+				if(pxLevelInfo^.IsMultiplayer()&&(iInfantryWar!=pxGame^.GetAttribInt("InfantryWar")))then
+					iInfantryWar=pxGame^.GetAttribInt("InfantryWar");
+					pxCSNode^.SetValue("InfantryWar",iInfantryWar);
+				endif;
 				m_bInfantryWar=iInfantryWar==1;
 				m_bInfantryWarChecked=true;
 			endif;
@@ -3114,6 +3369,10 @@ class CMirageSrvMgr
 				pxDeliveryUnbound=^(pxCSNode^.AddValue("DeliveryUnbound",iDeliveryUnbound));
 			else
 				iDeliveryUnbound=pxCSNode^.GetValueI("DeliveryUnbound");
+				if(pxLevelInfo^.IsMultiplayer()&&(iDeliveryUnbound!=pxGame^.GetAttribInt("DeliveryUnbound")))then
+					iDeliveryUnbound=pxGame^.GetAttribInt("DeliveryUnbound");
+					pxCSNode^.SetValue("DeliveryUnbound",iDeliveryUnbound);
+				endif;
 				m_bDeliveryUnbound=iDeliveryUnbound==1;
 				m_bDeliveryUnboundChecked=true;
 			endif;
@@ -3152,6 +3411,10 @@ class CMirageSrvMgr
 				pxGeneralAdvancement=^(pxCSNode^.AddValue("GeneralAdvancement",iGeneralAdvancement));
 			else
 				iGeneralAdvancement=pxCSNode^.GetValueI("GeneralAdvancement");
+				if(pxLevelInfo^.IsMultiplayer()&&(iGeneralAdvancement!=pxGame^.GetAttribInt("GeneralAdvancement")))then
+					iGeneralAdvancement=pxGame^.GetAttribInt("GeneralAdvancement");
+					pxCSNode^.SetValue("GeneralAdvancement",iGeneralAdvancement);
+				endif;
 				m_bGeneralAdvancement=iGeneralAdvancement==1;
 				m_bGeneralAdvancementChecked=true;
 			endif;
@@ -3190,6 +3453,10 @@ class CMirageSrvMgr
 				pxAllyBuildup=^(pxCSNode^.AddValue("AllyBuildup",iAllyBuildup));
 			else
 				iAllyBuildup=pxCSNode^.GetValueI("AllyBuildup");
+				if(pxLevelInfo^.IsMultiplayer()&&(iAllyBuildup!=pxGame^.GetAttribInt("AllyBuildup")))then
+					iAllyBuildup=pxGame^.GetAttribInt("AllyBuildup");
+					pxCSNode^.SetValue("AllyBuildup",iAllyBuildup);
+				endif;
 				m_bAllyBuildup=iAllyBuildup==1;
 				m_bAllyBuildupChecked=true;
 			endif;
@@ -3233,6 +3500,10 @@ class CMirageSrvMgr
 				pxDominationContinue=^(pxCSNode^.AddValue("DominationContinue",iDominationContinue));
 			else
 				iDominationContinue=pxCSNode^.GetValueI("DominationContinue");
+				if(pxLevelInfo^.IsMultiplayer()&&(iDominationContinue!=pxGame^.GetAttribInt("DominationContinue")))then
+					iDominationContinue=pxGame^.GetAttribInt("DominationContinue");
+					pxCSNode^.SetValue("DominationContinue",iDominationContinue);
+				endif;
 				m_bDominationContinue=iDominationContinue==1;
 				m_bDominationContinueChecked=true;
 			endif;
@@ -3271,6 +3542,10 @@ class CMirageSrvMgr
 				pxAlienCommands=^(pxCSNode^.AddValue("AlienCommands",iAlienCommands));
 			else
 				iAlienCommands=pxCSNode^.GetValueI("AlienCommands");
+				if(pxLevelInfo^.IsMultiplayer()&&(iAlienCommands!=pxGame^.GetAttribInt("AlienCommands")))then
+					iAlienCommands=pxGame^.GetAttribInt("AlienCommands");
+					pxCSNode^.SetValue("AlienCommands",iAlienCommands);
+				endif;
 				m_bAlienCommands=iAlienCommands==1;
 				m_bAllyBuildupChecked=true;
 			endif;
@@ -3386,6 +3661,7 @@ class CMirageSrvMgr
 		endfor;
 		return false;
 	endproc;
+	
 	export proc bool IsSlotForced(string p_sMap, int p_iID)
 		return (CheckCustomMap(p_sMap,"Players/Player_"+p_iID.ToString()+"/AddIfEmpty")||CheckCustomMap(p_sMap,"Players/Player_"+p_iID.ToString()+"/HiddenSlot"));
 	endproc;


### PR DESCRIPTION
* Fixing Node System overlap ontop of Custom Map UI system values. If the Nodes are Saved in Map CPropDB and on map aplied Map is Multiplayer, Nodes will not be counted, only UI values, except Nodes that are cannot be Set up through UI in lobby;
* Nodes that are tied to Lobby UI parameters are no longer work for multiplayer/skirmish maps, regardless if map is custom or not. Cutom map UI system now is only one way to preset those parameters;
* Nodes will work as before for SingleplayerCampaign maps;