### PR TITLE
Bugfixes and mechanics improvements

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -13,6 +13,7 @@ General:
  - Added player handicap(HP) option for Custom map control options
  - Custom map system parameters customization expanded. Player parameters are from now on can be applied only to exact Player
  - Predefined map server settings Node have been integrated into new Custom map UI system
+ - Single and Multiplayer campaign relation system has been improved. Players cant attack other neutral plaer if they are both in the same team from now on
  
 Maps:
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/CustomMapSettings.txt
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/misc/CustomMapSettings.txt
@@ -2013,7 +2013,7 @@ Root {
 				}
 			}
 		}
-		Prison_Island_[CUSTOM] {
+		Prison_Island {
 			Custom {
 				PointBuy {
 					Disabled = '1'
@@ -2186,9 +2186,9 @@ Root {
 		}
 		_MN_MP_4_AIRBATTLE {
 		}
-		Living_ruins_[CUSTOM] {
+		Living_ruins {
 		}
-		BfPW_-_Holy_City_[CUSTOM] {
+		BfPW_-_Holy_City {
 			LevelSettings {
 				CheckBox {
 					DisableWarpgate = '1'
@@ -2247,7 +2247,7 @@ Root {
 				}
 			}
 		}
-		Defender-Domination_[CUSTOM] {
+		Defender-Domination {
 			LevelSettings {
 				CheckBox {
 					LockDiplomacy = '1'
@@ -2277,7 +2277,7 @@ Root {
 				}
 			}
 		}
-		Divided_World_[CUSTOM] {
+		Divided_World {
 			LevelSettings {
 				CheckBox {
 					DisableWarpgate = '1'

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -8601,7 +8601,8 @@ class CFightingObj inherit CGameObj
 						//multiplayer: no friends no more.
 						if((!bIsMultiplayerGame || CMirageSrvMgr.Get().CheckCustomMap(sLevelName,"MultiplayerCampaign")) &&
 						(CSrvWrap.GetDiplomacyMgr().GetIsFriend(p_pxTarget^.GetOwner(), GetOwner())||
-						CSrvWrap.GetDiplomacyMgr().GetIsFriend(GetOwner(), p_pxTarget^.GetOwner())))then
+						CSrvWrap.GetDiplomacyMgr().GetIsFriend(GetOwner(), p_pxTarget^.GetOwner()))||
+						(pxLevelInfo^.GetOwnerTeam(GetOwner())==pxLevelInfo^.GetOwnerTeam(p_pxTarget^.GetOwner())))then
 							CFeedback.Print(GetOwner(), CFeedback.INFO, "_NT_DiplAttackNonEnemyIsNotAllowed\t"+sPlayerNameDefender, p_pxTarget^.GetPos());
 							return; // don't allow to attack in single player mode and on CUSTOM maps
 						elseif(bIsMultiplayerGame && pxFO!=null && AiOwner() && pxFO^.AiOwner())then


### PR DESCRIPTION
* From now on the players who are in the same team, but atleast one of them is neutral to another cannot be attacked by each other. For Campaign and MultiplayerCampaign only;
* Unused mapname prefixes removed from config file;