### PR TITLE
Ninigi rocket Ramp anim rot fix

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -45,6 +45,7 @@ Dustriders:
 
 Dragon Clan:
  - Fixed dilophosaurus nest and palisade wall disappearing from build menu under certain conditions
+ - Fixed incorrect rotation of turret and pterodactyl for rocket ramp while playing death animation
 
 Norsemen:
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/Building.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/buildings/Building.usl
@@ -2138,9 +2138,9 @@ class CRocketRamp inherit CTower
 			m_xTurret.GetObj()^.Delete();
 		endif;
 		if(p_sObjName.IsEmpty())then return; endif;
-		var vec3 vRot;
+		var vec3 vPos,vRot;
 		var Quat qRot;
-		GetLinkPosRotWorld(m_xTurretLink,vRot,qRot);
+		GetLinkPosRotWorld(m_xTurretLink,vPos,qRot);
 		qRot.ToVec3(vRot);
 		var ^CGameObj pxO=CSrvWrap.GetObjMgr()^.CreateObj(p_sObjName, GetOwner(),GetPos(),vRot);
 		if(pxO==null)then return();endif;
@@ -2212,7 +2212,10 @@ class CRocketRamp inherit CTower
 			pxGameObj^.SetSource(m_xTurret.GetObj());
 			pxGameObj^.Init("ninigi_rb_top", GetName(), 8.0, GetAge());
 			if(m_xTurret.IsValid())then
-				pxGameObj^.SetRot(m_xTurret.GetObj()^.GetRot());
+				var Quat qNewRot = m_xTurret.GetObj()^.GetRot();
+				var vec3 vNewRot; qNewRot.ToVec3(vNewRot);
+				vNewRot += {0.0,0.0,-3.14}; qNewRot.FromVec3(vNewRot);
+				pxGameObj^.SetRot(qNewRot);
 				pxGameObj^.SecRotAction(m_xTurret.GetObj()^.GetAdditionalRot(),0.0);
 			endif;
 		endif;
@@ -2221,7 +2224,10 @@ class CRocketRamp inherit CTower
 			pxGameObj^.SetSource(m_xBirdie.GetObj());
 			pxGameObj^.Init("ninigi_rb_bird", GetName(), 8.0, GetAge());
 			if(m_xTurret.IsValid())then
-				pxGameObj^.SetRot(m_xTurret.GetObj()^.GetRot());
+				var Quat qNewRot = m_xTurret.GetObj()^.GetRot();
+				var vec3 vNewRot; qNewRot.ToVec3(vNewRot);
+				vNewRot += {0.0,0.0,-3.14}; qNewRot.FromVec3(vNewRot);
+				pxGameObj^.SetRot(qNewRot);
 				pxGameObj^.SecRotAction(m_xTurret.GetObj()^.GetAdditionalRot(),0.0);
 			endif;
 		endif;
@@ -2241,7 +2247,10 @@ class CRocketRamp inherit CTower
 				pxGameObj^.SetSource(m_xBirdie.GetObj());
 				pxGameObj^.Init(m_xBirdie.GetObj()^.GetGfxName(), GetName(), 125.0f, GetAge());
 				if(m_xTurret.IsValid())then
-					pxGameObj^.SetRot(m_xTurret.GetObj()^.GetRot());
+					var Quat qNewRot = m_xTurret.GetObj()^.GetRot();
+					var vec3 vNewRot; qNewRot.ToVec3(vNewRot);
+					vNewRot += {0.0,0.0,-3.14}; qNewRot.FromVec3(vNewRot);
+					pxGameObj^.SetRot(qNewRot);
 					pxGameObj^.SecRotAction(m_xTurret.GetObj()^.GetAdditionalRot(),0.0);
 				endif;
 			endif;
@@ -2752,7 +2761,12 @@ class CTower inherit CBuilding
 			if(pxGameObj!=null)then
 				pxGameObj^.SetSource(m_xTurret.GetObj());
 				pxGameObj^.Init(m_xTurret.GetObj()^.GetGfxName(), GetName(), 125.0f, GetAge());
-				pxGameObj^.SetRot(m_xTurret.GetObj()^.GetRot());
+				var Quat qNewRot = m_xTurret.GetObj()^.GetRot();
+				if(GetClassName()=="ninigi_rocket_ramp")then
+					var vec3 vNewRot; qNewRot.ToVec3(vNewRot);
+					vNewRot += {0.0,0.0,-3.14}; qNewRot.FromVec3(vNewRot);
+				endif;
+				pxGameObj^.SetRot(qNewRot);
 				pxGameObj^.SecRotAction(m_xTurret.GetObj()^.GetAdditionalRot(),0.0);
 			endif;
 		endif;


### PR DESCRIPTION
Fixed incorrect rotation for parts of modular object "ninigi_rocket_ramp" during destruction animatin.Because of the diffrent rotation of model with rotation coords [0 0 0] there were visual errors for "ninigi_rb_top" and "ninigi_rb_bird";