### PR TITLE
Revert "Removing trader zeppeling from build menu and pointbuy"

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -6,7 +6,6 @@ MIRAGE 2.6.8
 General:
  - Fixed freezing on in match menu opening menu if screen resolution was not 2560x1440
  - Fixed missing eighth player name in the statistics window - timeline tab
- - Fixed issue when "TradingDisabled" server option was enabled, the trader zeppeling were not removed from the pointbuy and from build list
  - Chat window has been increased and now uses multiline
  - Added chat player colors to the recipient selection dropdown menu (in match only)
  - Added COOP campaign and custom maps sorting in map list

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PointBuy/PointBuyMenu.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PointBuy/PointBuyMenu.usl
@@ -146,7 +146,7 @@ class CPointBuyMenu inherit CStaticCtrl
 		endif;
 		// Henry: disable traders if needed
 		if(CGameWrap.GetGame().GetAttribInt("RemoveTrading")==1)then
-			if(p_sClass=="aje_trade_dino"||p_sClass=="hu_cart"||p_sClass=="ninigi_cart"||p_sClass=="seas_trade_dino"||p_sClass.Find("_zeppelin")!=-1)then return false; endif;
+			if(p_sClass=="aje_trade_dino"||p_sClass=="hu_cart"||p_sClass=="ninigi_cart"||p_sClass=="seas_trade_dino")then return false; endif;
 		endif;
 		// Henry: disable epoch 6 units if needed
 		if(CGameWrap.GetGame().GetAttribInt("MaxEpoch")<6)then

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PointBuy/PyramidDialog.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/UI/PointBuy/PyramidDialog.usl
@@ -325,7 +325,7 @@ class CPyramidDialog inherit CStaticCtrlEx
 	endproc;
 	
 	export proc bool IsTrader(ref string p_rsClass, string p_sTribe)
-		if(p_rsClass=="aje_trade_dino"||p_rsClass=="hu_cart"||p_rsClass=="ninigi_cart"||p_rsClass=="seas_trade_dino"||p_rsClass.Find("_zeppelin")!=-1)then
+		if(p_rsClass=="aje_trade_dino"||p_rsClass=="hu_cart"||p_rsClass=="ninigi_cart"||p_rsClass=="seas_trade_dino")then
 			p_sTribe.MakeLower();
 			var string sUnit="_warrior";
 			if(p_sTribe=="aje")then

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/FightingObj/FightingObj.usl
@@ -13756,8 +13756,6 @@ class CFightingObj inherit CGameObj
 			return true;
 		elseif((sName=="hu_fishing_boat"||sName=="ninigi_fishing_boat")&&CRequirementsMgr.Get().CheckInvention(this, GetOwner(), "trade_ship", GetTribeName()))then
 			return true;
-		elseif(sName.Find("_zeppelin")!=-1)then
-			return true;
 		endif;
 		return false;
 	endproc;

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/misc/StartLocation.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Server/classes/misc/StartLocation.usl
@@ -1299,7 +1299,7 @@ class CStartLocationMgr inherit IStartLocationMgr
 	
 	export proc bool CheckTrading(ref string p_rsClass, string p_sTribe)
 		if(!CMirageSrvMgr.Get().RemoveTrading())then return true; endif;
-		if(p_rsClass=="aje_trade_dino"||p_rsClass=="hu_cart"||p_rsClass=="ninigi_cart"||p_rsClass=="seas_trade_dino"||p_rsClass.Find("_zeppelin")!=-1)then
+		if(p_rsClass=="aje_trade_dino"||p_rsClass=="hu_cart"||p_rsClass=="ninigi_cart"||p_rsClass=="seas_trade_dino")then
 			p_sTribe.MakeLower();
 			var string sUnit="_warrior";
 			if(p_sTribe=="aje")then


### PR DESCRIPTION
Reverts Tatsukio/MIRAGE#424 - perhaps its better to disable the trading itself instead of the unit