### PR TITLE
Turret addon on "ninigi_water_turret"'s Ghost

### DIFF
--- a/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
+++ b/GameFiles/Basic/Data/MIRAGE/ReadMe.txt
@@ -44,6 +44,7 @@ Dustriders:
  - Fixed default dustriders 10000 points presets that would cause all units and resources to be removed after loading
 
 Dragon Clan:
+ - Water turret's ghost from now on has turret
  - Fixed dilophosaurus nest and palisade wall disappearing from build menu under certain conditions
  - Fixed incorrect rotation of turret and pterodactyl for rocket ramp while playing death animation
 

--- a/GameFiles/Basic/Data/MIRAGE/Scripts/Game/controller/MainController.usl
+++ b/GameFiles/Basic/Data/MIRAGE/Scripts/Game/controller/MainController.usl
@@ -387,6 +387,11 @@ TODO.
 				endif;
 				pxObjMgr^.AddGhost(sRally);
 				var ^CGhost pxG=pxObjMgr^.GetGhostIndex(avPositions.NumEntries()-1);
+				if(sRally=="ninigi_water_turret")then
+					var CFourCC xLink = "we";
+					var int iLinkID = pxG^.GetLinkID(xLink);
+					pxG^.LinkGfx(iLinkID, "ninigi_water_turret_cannon");
+				endif;
 				pxObjMgr^.SetGhostClass(avPositions.NumEntries()-1,sRally);
 				pxG^.SetVisible(true);
 				pxG^.SetPos(vPos);


### PR DESCRIPTION
* From now on turret part also visible on Ghost objects for "ninigi_water_turrret";